### PR TITLE
fix: Update Cloudflare Pages build command

### DIFF
--- a/.docs/cloudflare-pages-setup.md
+++ b/.docs/cloudflare-pages-setup.md
@@ -82,13 +82,13 @@
 
 ### 4. ビルド設定
 
-**重要:** pnpmを使用するため、ビルドコマンドをカスタマイズします。
+**重要:** Cloudflare Pagesは`package.json`の`packageManager`フィールドからpnpmを自動検出します。
 
-#### 推奨設定（方法1: pnpmグローバルインストール）
+#### 推奨設定
 
 ```bash
 # Build command
-npm i -g pnpm && pnpm install && pnpm build
+pnpm build
 
 # Build output directory
 out
@@ -97,15 +97,7 @@ out
 (空欄)
 ```
 
-#### 代替設定（方法2: npx pnpm）
-
-```bash
-# Build command
-npx pnpm install && npx pnpm build
-
-# Build output directory
-out
-```
+**Note:** `pnpm install`はCloudflare Pagesが自動実行するため、ビルドコマンドには不要です。
 
 #### 環境変数（オプション）
 

--- a/README.md
+++ b/README.md
@@ -182,10 +182,11 @@ http://localhost:3000
 3. GitHubリポジトリ **`Naruto-Shelter-Map`** を接続
 4. フレームワークプリセット: **`Next.js (Static HTML Export)`**
 5. ビルド設定:
-   - **ビルドコマンド:** `npm i -g pnpm && pnpm install && pnpm build`
+   - **ビルドコマンド:** `pnpm build`
    - **ビルド出力ディレクトリ:** `out`
-   - **Node.js バージョン:** `20`
 6. **「Save and Deploy」** をクリック
+
+> **Note:** pnpmは`package.json`の`packageManager`フィールドから自動検出されます。
 
 デプロイ完了後、`https://naruto-shelter-map.pages.dev` のようなURLが生成されます。
 


### PR DESCRIPTION
## 問題
Cloudflare Pagesデプロイ時に以下のエラーが発生：

```
npm error EEXIST: file already exists
npm error File exists: /opt/buildhome/.asdf/installs/nodejs/20.19.2/bin/pnpx
```

## 原因
Cloudflare Pagesは`package.json`の`packageManager`フィールドから**pnpm 9.0.0を自動検出・インストール**しているのに、ビルドコマンドで再度`npm i -g pnpm`を実行しようとして競合。

ビルドログ:
```
2025-10-18T14:00:58.225006Z	Detected the following tools from environment: nodejs@20.19.2, pnpm@9.0.0
...
2025-10-18T14:01:09.246598Z	Installing project dependencies: pnpm install
```

## 修正内容

### ビルドコマンド変更

**Before:**
```bash
npm i -g pnpm && pnpm install && pnpm build
```

**After:**
```bash
pnpm build
```

### 変更理由
- ✅ Cloudflare PagesがpackageManagerフィールドからpnpmを自動検出
- ✅ `pnpm install`も自動実行される
- ✅ ビルドコマンドは`pnpm build`のみで十分

### 更新ファイル
- `.docs/cloudflare-pages-setup.md` - ビルドコマンド修正 + 自動検出の説明追加
- `README.md` - クイックスタートのビルドコマンド修正

## テストプラン
- [x] ドキュメント修正
- [ ] Cloudflare Pages設定でビルドコマンドを`pnpm build`に変更
- [ ] デプロイ再実行（Retry deployment）
- [ ] ビルド成功確認

## 次のアクション
1. このPRをマージ
2. Cloudflare Pages設定画面で**Build command**を`pnpm build`に変更
3. 失敗したデプロイを**Retry deployment**

## 関連Issue
- Refs #7

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)