### PR TITLE
feat(mobile): Implement bottom sheet UI pattern for mobile view

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,12 +3,15 @@
 import { ShelterMap } from '@/components/map/Map';
 import { SearchBar } from '@/components/search/SearchBar';
 import { ShelterList } from '@/components/shelter/ShelterList';
+import { BottomSheet, type SheetState } from '@/components/mobile/BottomSheet';
+import { SheetContent } from '@/components/mobile/SheetContent';
 import { useShelters } from '@/hooks/useShelters';
 import { useMemo, useState } from 'react';
 
 export default function HomePage() {
   const { data, isLoading, error } = useShelters();
   const [searchQuery, setSearchQuery] = useState('');
+  const [sheetState, setSheetState] = useState<SheetState>('half');
 
   // 検索フィルタリング
   const filteredShelters = useMemo(() => {
@@ -52,37 +55,71 @@ export default function HomePage() {
   }
 
   return (
-    <div className="flex h-screen flex-col lg:flex-row lg:overflow-hidden">
-      {/* サイドバー（モバイル: 上部、デスクトップ: 左側） */}
-      <div className="flex max-h-[50vh] w-full flex-col border-b bg-white lg:h-full lg:max-h-none lg:w-96 lg:border-b-0 lg:border-r">
-        {/* ヘッダー */}
-        <div className="border-b p-4">
-          <h1 className="mb-2 text-2xl font-bold text-gray-900">
-            鳴門市避難所マップ
-          </h1>
-          <p className="text-sm text-gray-600">
-            {filteredShelters.length}件の避難所
-          </p>
+    <>
+      {/* モバイルレイアウト（< 1024px） */}
+      <div className="flex h-screen flex-col lg:hidden">
+        {/* ヘッダー + 検索（sticky） */}
+        <header className="sticky top-0 z-30 bg-white/95 backdrop-blur-sm border-b">
+          <div className="p-4">
+            <h1 className="text-xl font-bold text-gray-900">
+              鳴門市避難所マップ
+            </h1>
+          </div>
+          <div className="px-4 pb-4">
+            <SearchBar
+              onSearch={setSearchQuery}
+              placeholder="避難所名・住所・災害種別で検索..."
+            />
+          </div>
+        </header>
+
+        {/* 地図エリア（フルスクリーン） */}
+        <div className="flex-1">
+          <ShelterMap shelters={filteredShelters} />
         </div>
 
-        {/* 検索バー */}
-        <div className="border-b p-4">
-          <SearchBar
-            onSearch={setSearchQuery}
-            placeholder="避難所名・住所・災害種別で検索..."
+        {/* Bottom Sheet */}
+        <BottomSheet state={sheetState} onStateChange={setSheetState}>
+          <SheetContent
+            shelters={filteredShelters}
+            onMapViewRequest={() => setSheetState('closed')}
           />
-        </div>
-
-        {/* 避難所リスト */}
-        <div className="min-h-0 flex-1 overflow-y-auto p-4">
-          <ShelterList shelters={filteredShelters} />
-        </div>
+        </BottomSheet>
       </div>
 
-      {/* 地図エリア */}
-      <div className="h-96 flex-1 lg:h-full">
-        <ShelterMap shelters={filteredShelters} />
+      {/* デスクトップレイアウト（>= 1024px） */}
+      <div className="hidden lg:flex lg:h-screen lg:flex-row lg:overflow-hidden">
+        {/* サイドバー（左側） */}
+        <div className="flex h-full w-96 flex-col border-r bg-white">
+          {/* ヘッダー */}
+          <div className="border-b p-4">
+            <h1 className="mb-2 text-2xl font-bold text-gray-900">
+              鳴門市避難所マップ
+            </h1>
+            <p className="text-sm text-gray-600">
+              {filteredShelters.length}件の避難所
+            </p>
+          </div>
+
+          {/* 検索バー */}
+          <div className="border-b p-4">
+            <SearchBar
+              onSearch={setSearchQuery}
+              placeholder="避難所名・住所・災害種別で検索..."
+            />
+          </div>
+
+          {/* 避難所リスト */}
+          <div className="min-h-0 flex-1 overflow-y-auto p-4">
+            <ShelterList shelters={filteredShelters} />
+          </div>
+        </div>
+
+        {/* 地図エリア（右側） */}
+        <div className="h-full flex-1">
+          <ShelterMap shelters={filteredShelters} />
+        </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/src/components/mobile/BottomSheet.tsx
+++ b/src/components/mobile/BottomSheet.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { type ReactNode, useEffect } from 'react';
+import { cn } from '@/lib/utils';
+
+export type SheetState = 'closed' | 'half' | 'full';
+
+interface BottomSheetProps {
+  state: SheetState;
+  onStateChange: (state: SheetState) => void;
+  children: ReactNode;
+}
+
+const SHEET_HEIGHTS: Record<SheetState, string> = {
+  closed: 'h-[60px]', // タブバーのみ表示
+  half: 'h-[50vh]',
+  full: 'h-[90vh]',
+};
+
+export function BottomSheet({
+  state,
+  onStateChange,
+  children,
+}: BottomSheetProps) {
+  // スクロールロック（シートが開いている時）
+  useEffect(() => {
+    if (state !== 'closed') {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = '';
+    }
+
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [state]);
+
+  return (
+    <>
+      {/* オーバーレイ（closed以外で表示） */}
+      {state !== 'closed' && (
+        <div
+          className="fixed inset-0 bg-black/20 z-40 lg:hidden"
+          onClick={() => onStateChange('closed')}
+        />
+      )}
+
+      {/* Bottom Sheet */}
+      <div
+        className={cn(
+          'fixed bottom-0 left-0 right-0 bg-white rounded-t-2xl shadow-2xl z-50 lg:hidden',
+          'transition-all duration-300 ease-in-out',
+          SHEET_HEIGHTS[state],
+        )}
+      >
+        {/* ドラッグハンドル */}
+        <div
+          className="flex items-center justify-center py-3 cursor-pointer"
+          onClick={() => {
+            if (state === 'closed') onStateChange('half');
+            else if (state === 'half') onStateChange('full');
+            else onStateChange('closed');
+          }}
+        >
+          <div className="w-12 h-1 bg-gray-300 rounded-full" />
+        </div>
+
+        {/* コンテンツ */}
+        <div className="h-[calc(100%-40px)] overflow-hidden">{children}</div>
+      </div>
+    </>
+  );
+}

--- a/src/components/mobile/SheetContent.tsx
+++ b/src/components/mobile/SheetContent.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useState } from 'react';
+import type { ShelterFeature } from '@/types/shelter';
+import { ShelterList } from '@/components/shelter/ShelterList';
+import { ViewModeTabs, type ViewMode } from './ViewModeTabs';
+
+interface SheetContentProps {
+  shelters: ShelterFeature[];
+  onMapViewRequest: () => void;
+}
+
+export function SheetContent({
+  shelters,
+  onMapViewRequest,
+}: SheetContentProps) {
+  const [viewMode, setViewMode] = useState<ViewMode>('list');
+
+  const handleModeChange = (mode: ViewMode): void => {
+    setViewMode(mode);
+    if (mode === 'map') {
+      // 地図タブ選択時はシートを閉じる
+      onMapViewRequest();
+    }
+  };
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* タブ */}
+      <ViewModeTabs
+        mode={viewMode}
+        onModeChange={handleModeChange}
+        shelterCount={shelters.length}
+      />
+
+      {/* リスト表示 */}
+      {viewMode === 'list' && (
+        <div className="flex-1 overflow-y-auto p-4">
+          <ShelterList shelters={shelters} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/mobile/ViewModeTabs.tsx
+++ b/src/components/mobile/ViewModeTabs.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+
+export type ViewMode = 'list' | 'map';
+
+interface ViewModeTabsProps {
+  mode: ViewMode;
+  onModeChange: (mode: ViewMode) => void;
+  shelterCount: number;
+}
+
+export function ViewModeTabs({
+  mode,
+  onModeChange,
+  shelterCount,
+}: ViewModeTabsProps) {
+  return (
+    <div className="flex items-center border-b bg-white">
+      {/* リストタブ */}
+      <button
+        type="button"
+        className={cn(
+          'flex-1 py-3 px-4 font-medium transition-all duration-200',
+          'focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-inset',
+          mode === 'list'
+            ? 'border-b-2 border-blue-600 text-blue-600'
+            : 'text-gray-600 hover:text-gray-900',
+        )}
+        onClick={() => onModeChange('list')}
+      >
+        <svg
+          className="inline h-5 w-5 mr-2"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M4 6h16M4 10h16M4 14h16M4 18h16"
+          />
+        </svg>
+        リスト ({shelterCount}件)
+      </button>
+
+      {/* 地図タブ */}
+      <button
+        type="button"
+        className={cn(
+          'flex-1 py-3 px-4 font-medium transition-all duration-200',
+          'focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-inset',
+          mode === 'map'
+            ? 'border-b-2 border-blue-600 text-blue-600'
+            : 'text-gray-600 hover:text-gray-900',
+        )}
+        onClick={() => onModeChange('map')}
+      >
+        <svg
+          className="inline h-5 w-5 mr-2"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l4.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-.553-.894L15 4m0 13V4m0 0L9 7"
+          />
+        </svg>
+        地図
+      </button>
+    </div>
+  );
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]): string {
+  return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
## 📱 Phase 1: Bottom Sheet UI Implementation

This PR implements a modern bottom sheet UI pattern for mobile devices, inspired by Google Maps and Apple Maps.

### 🎯 What's Changed

#### 新規コンポーネント (New Components)
- ✅ **BottomSheet.tsx**: Bottom sheet container with 3 states
  - `closed` (60px) - Tabs only
  - `half` (50vh) - Default state, list visible
  - `full` (90vh) - Expanded view
  - Smooth CSS transitions (300ms)
  - Overlay with click-to-close
  - Body scroll lock when open

- ✅ **ViewModeTabs.tsx**: Tab switcher (List ↔ Map)
  - Icons + text labels with shelter count
  - Active state styling
  - Accessible buttons with focus rings

- ✅ **SheetContent.tsx**: Content manager
  - Tab state management
  - Auto-close on Map tab selection

- ✅ **lib/utils.ts**: Utility functions
  - `cn()` for Tailwind class merging

#### モバイルUI改善 (Mobile UI Improvements)
- 🗺️ Full-screen map background
- 📍 Sticky header with backdrop blur
- 📋 Bottom sheet with drag handle
- 🔄 Tab switching between List and Map
- 📱 Responsive design (< 1024px)

#### デスクトップレイアウト (Desktop Layout)
- ✅ **Unchanged** - maintains sidebar + map layout
- ✅ Responsive breakpoint works correctly

### 🐛 Bug Fixes
- Fixed: Tabs invisible when sheet closed (h-0 → h-[60px])
- Fixed: Unable to reopen sheet after closing

### 📸 Screenshots

**Mobile - Closed State (tabs only):**
![mobile-closed](https://github.com/user-attachments/assets/...)

**Mobile - Half State (default):**
![mobile-half](https://github.com/user-attachments/assets/...)

**Mobile - Full State (expanded):**
![mobile-full](https://github.com/user-attachments/assets/...)

**Desktop - Unchanged:**
![desktop](https://github.com/user-attachments/assets/...)

### ✅ Test Results
- [x] Bottom sheet state transitions (closed → half → full → closed)
- [x] Tab switching (List ↔ Map)
- [x] Desktop layout unchanged
- [x] Mobile responsive (tested at 375x667)
- [x] Smooth CSS animations
- [x] No console errors
- [x] TypeScript type-safe

### 🔄 Next Steps (Future PRs)
- **Phase 2**: Add Framer Motion for swipe gestures
- **Phase 3**: Polish animations and accessibility
- **Issue #21**: Add missing shelter data

### 📚 References
- Refs: `.docs/00-MASTER-PLAN.md` (Phase 1: モバイルUI改善)
- Partial fix for: #20 (improves mobile UX)

### 🧪 How to Test
1. Checkout this branch
2. Run `pnpm dev`
3. Open http://localhost:3001 on mobile device or resize browser to 375px width
4. Test tab switching and drag handle
5. Verify desktop layout at 1024px+ width

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)