### PR TITLE
feat(a11y): Add prefers-reduced-motion support to bottom sheet

### DIFF
--- a/src/components/mobile/BottomSheet.tsx
+++ b/src/components/mobile/BottomSheet.tsx
@@ -3,6 +3,7 @@
 import { calculateSnapPoint, getSheetHeight } from '@/lib/gestures';
 import { cn } from '@/lib/utils';
 import { useFocusTrap } from '@/hooks/useFocusTrap';
+import { useReducedMotion } from '@/hooks/useReducedMotion';
 import { AnimatePresence, type PanInfo, motion } from 'framer-motion';
 import { type ReactNode, type KeyboardEvent, useEffect, useState } from 'react';
 
@@ -22,6 +23,9 @@ export function BottomSheet({
   const [viewportHeight, setViewportHeight] = useState(
     typeof window !== 'undefined' ? window.innerHeight : 667
   );
+
+  // モーション設定を検出
+  const shouldReduceMotion = useReducedMotion();
 
   // フォーカストラップ（シートが開いている時）
   const sheetRef = useFocusTrap<HTMLDivElement>(state !== 'closed');
@@ -122,7 +126,11 @@ export function BottomSheet({
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
-            transition={{ duration: 0.2 }}
+            transition={
+              shouldReduceMotion
+                ? { duration: 0 }
+                : { duration: 0.2 }
+            }
             className="fixed inset-0 bg-black/20 z-40 lg:hidden"
             onClick={() => onStateChange('closed')}
             aria-hidden="true"
@@ -139,15 +147,19 @@ export function BottomSheet({
         aria-hidden={state === 'closed'}
         drag="y"
         dragConstraints={{ top: 0, bottom: 0 }}
-        dragElastic={0.1}
+        dragElastic={shouldReduceMotion ? 0 : 0.1}
         onDragEnd={handleDragEnd}
         onKeyDown={handleKeyDown}
         animate={{ height: currentHeight }}
-        transition={{
-          type: 'spring',
-          damping: 30,
-          stiffness: 300,
-        }}
+        transition={
+          shouldReduceMotion
+            ? { duration: 0.2, ease: 'easeOut' }
+            : {
+                type: 'spring',
+                damping: 30,
+                stiffness: 300,
+              }
+        }
         className={cn(
           'fixed bottom-0 left-0 right-0 bg-white rounded-t-2xl shadow-2xl z-50 lg:hidden',
           'touch-none', // タッチイベントを適切に処理
@@ -168,7 +180,7 @@ export function BottomSheet({
           tabIndex={0}
           className="flex items-center justify-center py-3 cursor-grab active:cursor-grabbing focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-inset"
           onClick={handleHandleClick}
-          whileTap={{ scale: 1.05 }}
+          whileTap={shouldReduceMotion ? {} : { scale: 1.05 }}
         >
           <div className="w-12 h-1 bg-gray-300 rounded-full" />
         </motion.div>

--- a/src/hooks/useReducedMotion.ts
+++ b/src/hooks/useReducedMotion.ts
@@ -1,0 +1,43 @@
+import { useState, useEffect } from 'react';
+
+/**
+ * ユーザーのprefers-reduced-motion設定を検出するカスタムフック
+ *
+ * @returns {boolean} `true`の場合、アニメーションを減らすべき
+ *
+ * @example
+ * ```tsx
+ * const shouldReduceMotion = useReducedMotion();
+ *
+ * <motion.div
+ *   animate={{ opacity: 1 }}
+ *   transition={shouldReduceMotion ? { duration: 0 } : { duration: 0.3 }}
+ * />
+ * ```
+ */
+export function useReducedMotion(): boolean {
+  const [shouldReduceMotion, setShouldReduceMotion] = useState(false);
+
+  useEffect(() => {
+    // メディアクエリを作成
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+    // 初期値を設定
+    setShouldReduceMotion(mediaQuery.matches);
+
+    // 変更を監視
+    const handleChange = (event: MediaQueryListEvent): void => {
+      setShouldReduceMotion(event.matches);
+    };
+
+    // リスナーを追加
+    mediaQuery.addEventListener('change', handleChange);
+
+    // クリーンアップ
+    return () => {
+      mediaQuery.removeEventListener('change', handleChange);
+    };
+  }, []);
+
+  return shouldReduceMotion;
+}


### PR DESCRIPTION
## Summary

Phase 3-2の実装：`prefers-reduced-motion`対応を追加しました。

- ✅ `useReducedMotion`カスタムフックを作成
- ✅ BottomSheetコンポーネントでモーション設定を検出
- ✅ アニメーションを条件分岐で簡素化

## 変更内容

### 新規ファイル
- `src/hooks/useReducedMotion.ts` - prefers-reduced-motion検出フック

### 更新ファイル
- `src/components/mobile/BottomSheet.tsx` - 3箇所のアニメーション設定を条件分岐

### アニメーション変更

**通常モード（prefers-reduced-motion: no-preference）**
- オーバーレイ: フェードイン/アウト 0.2s
- シート高さ: Spring アニメーション（damping: 30, stiffness: 300）
- ドラッグエラスティック: 0.1（バウンス効果）
- ハンドルタップ: scale 1.05

**Motion軽減モード（prefers-reduced-motion: reduce）**
- オーバーレイ: フェードなし（即座に表示/非表示）
- シート高さ: シンプルなイージング（ease-out 0.2s）
- ドラッグエラスティック: 0（バウンスなし）
- ハンドルタップ: スケールなし

## テスト方法

### ブラウザで確認

**Chrome/Edge:**
1. DevTools → 設定（⚙️）→ Rendering
2. "Emulate CSS media feature prefers-reduced-motion" → "reduce"に設定

**Firefox:**
1. DevTools → インスペクタ → ルール
2. メディアクエリに`@media (prefers-reduced-motion: reduce)`を追加

### 期待される動作
- ✅ Motion軽減モード時、アニメーションがシンプルになる
- ✅ 通常モード時、従来通りのSpringアニメーション
- ✅ 設定変更がリアルタイムで反映される

## アクセシビリティ準拠

- **WCAG 2.1 Level A**: [2.3.3 Animation from Interactions](https://www.w3.org/WAI/WCAG21/Understanding/animation-from-interactions.html)
- モーション感受性のあるユーザー（前庭障害、めまい等）に配慮

## 関連Issue

Phase 3のロードマップに基づく実装

## スクリーンショット

（実装内容のため、視覚的な変更はユーザーの設定により異なります）

🤖 Generated with [Claude Code](https://claude.com/claude-code)