### PR TITLE
feat(mobile): Add peek state to bottom sheet (4-state system)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,7 +11,7 @@ import { useMemo, useState } from 'react';
 export default function HomePage() {
   const { data, isLoading, error } = useShelters();
   const [searchQuery, setSearchQuery] = useState('');
-  const [sheetState, setSheetState] = useState<SheetState>('half');
+  const [sheetState, setSheetState] = useState<SheetState>('peek');
 
   // 検索フィルタリング
   const filteredShelters = useMemo(() => {

--- a/src/lib/gestures.ts
+++ b/src/lib/gestures.ts
@@ -10,6 +10,8 @@ export function getSheetHeight(
   switch (state) {
     case 'closed':
       return 60; // タブバーのみ
+    case 'peek':
+      return 120; // タブバー + カード1枚の上部がちらっと見える
     case 'half':
       return viewportHeight * 0.5; // 50vh
     case 'full':
@@ -33,33 +35,39 @@ export function calculateSnapPoint(
   const velocityThreshold = 500; // px/s
 
   const closedHeight = getSheetHeight('closed', viewportHeight);
+  const peekHeight = getSheetHeight('peek', viewportHeight);
   const halfHeight = getSheetHeight('half', viewportHeight);
   const fullHeight = getSheetHeight('full', viewportHeight);
 
   // 勢いよく上スワイプ → 展開
   if (velocity < -velocityThreshold) {
     if (currentY < halfHeight) return 'full';
-    return 'half';
+    if (currentY < peekHeight) return 'half';
+    return 'peek';
   }
 
   // 勢いよく下スワイプ → 閉じる
   if (velocity > velocityThreshold) {
-    if (currentY > halfHeight) return 'closed';
+    if (currentY > halfHeight) return 'peek';
+    if (currentY > peekHeight) return 'closed';
     return 'half';
   }
 
   // 速度が遅い場合は最も近い状態へスナップ
   const distanceToClosed = Math.abs(currentY - closedHeight);
+  const distanceToPeek = Math.abs(currentY - peekHeight);
   const distanceToHalf = Math.abs(currentY - halfHeight);
   const distanceToFull = Math.abs(currentY - fullHeight);
 
   const minDistance = Math.min(
     distanceToClosed,
+    distanceToPeek,
     distanceToHalf,
     distanceToFull
   );
 
   if (minDistance === distanceToClosed) return 'closed';
+  if (minDistance === distanceToPeek) return 'peek';
   if (minDistance === distanceToFull) return 'full';
   return 'half';
 }


### PR DESCRIPTION
## Summary

Phase 3-4の実装：Bottom Sheetに4つ目の状態「peek」を追加しました。

- ✅ 4状態システムの実装：closed → peek → half → full
- ✅ 初期状態を'peek'に変更（即座にコンテンツ表示）
- ✅ ジェスチャー・キーボード・クリック操作を4状態対応

## 変更内容

### 新しい状態「peek」

**定義:**
- 高さ: **120px**（タブバー40px + カード上部80px）
- 目的: ユーザーがインタラクションせずにコンテンツをプレビューできる

**4状態の高さ:**
| 状態 | 高さ | 説明 |
|------|------|------|
| **closed** | 60px | タブバーのみ |
| **peek** | 120px | カード1枚の上部がちらっと見える（新規） |
| **half** | 50vh | カード数枚が見える |
| **full** | 90vh | ほぼ全画面 |

### ファイル変更

#### 1. `src/components/mobile/BottomSheet.tsx`

**型定義:**
```typescript
// Before
export type SheetState = 'closed' | 'half' | 'full';

// After
export type SheetState = 'closed' | 'peek' | 'half' | 'full';
```

**クリック操作（4状態サイクル）:**
```typescript
// closed → peek → half → full → closed
const handleHandleClick = (): void => {
  if (state === 'closed') onStateChange('peek');
  else if (state === 'peek') onStateChange('half');
  else if (state === 'half') onStateChange('full');
  else onStateChange('closed');
};
```

**キーボード操作:**
- ArrowUp: closed → peek → half → full
- ArrowDown: full → half → peek → closed
- Escape: どの状態からも → closed

**フォーカストラップ・スクロールロック:**
- Before: `state !== 'closed'`（3状態すべて）
- After: `state === 'half' || state === 'full'`（2状態のみ）
- peek状態では背景操作可能（UX向上）

**オーバーレイ:**
- Before: `state !== 'closed'`
- After: `state === 'half' || state === 'full'`
- peek状態では背景が暗くならない

**ARIA属性:**
```typescript
aria-modal={state === 'half' || state === 'full'}
aria-hidden={state === 'closed'}
```

#### 2. `src/lib/gestures.ts`

**高さ計算:**
```typescript
export function getSheetHeight(state: SheetState, viewportHeight: number): number {
  switch (state) {
    case 'closed': return 60;
    case 'peek': return 120;  // 新規追加
    case 'half': return viewportHeight * 0.5;
    case 'full': return viewportHeight * 0.9;
  }
}
```

**スナップポイント計算（4状態対応）:**
```typescript
// 速度判定に4つの高さすべてを考慮
const closedHeight = getSheetHeight('closed', viewportHeight);
const peekHeight = getSheetHeight('peek', viewportHeight);
const halfHeight = getSheetHeight('half', viewportHeight);
const fullHeight = getSheetHeight('full', viewportHeight);

// 距離計算で最も近い状態を選択
const minDistance = Math.min(
  distanceToClosed,
  distanceToPeek,    // 新規追加
  distanceToHalf,
  distanceToFull
);
```

#### 3. `src/app/page.tsx`

**初期状態変更:**
```typescript
// Before
const [sheetState, setSheetState] = useState<SheetState>('half');

// After
const [sheetState, setSheetState] = useState<SheetState>('peek');
```

## UX向上ポイント

### 1. 即座の情報開示
- **Before**: アプリ起動時は地図のみ表示、リストはシートを開かないと見えない
- **After**: 起動直後からカードが1枚見える → 避難所があることを即座に認識

### 2. 段階的な情報開示
- **4段階の状態遷移**: ユーザーが必要に応じて情報量を調整可能
- **視覚的フィードバック**: スワイプ中も4つのスナップポイントにスムーズに吸着

### 3. 背景操作の柔軟性
- **peek状態**: オーバーレイなし、スクロールロックなし
  - 地図を操作しながらリストをちらっと確認可能
- **half/full状態**: オーバーレイあり、フォーカストラップあり
  - モーダル的な操作に集中

### 4. アクセシビリティ維持
- キーボード操作（ArrowUp/Down）で4状態を順番に遷移
- スクリーンリーダー対応（aria-valuetext更新）
- フォーカス管理の最適化

## テスト方法

### 1. 初期表示確認
1. アプリを開く
2. Bottom Sheetが120px（peek状態）で表示されることを確認
3. カードの上部（名前・住所）が見えることを確認

### 2. 4状態遷移
**スワイプ操作:**
- 上スワイプ: peek → half → full
- 下スワイプ: full → half → peek → closed

**クリック操作（ハンドル）:**
- closed → peek → half → full → closed（サイクル）

**キーボード操作:**
- ArrowUp: 上位状態へ
- ArrowDown: 下位状態へ
- Escape: closedへ

### 3. オーバーレイ・フォーカストラップ
- peek状態: 背景クリック可能、地図操作可能
- half/full状態: 背景暗転、シート内にフォーカストラップ

## ビフォー・アフター比較

| 項目 | Before | After |
|------|--------|-------|
| **状態数** | 3（closed, half, full） | 4（closed, **peek**, half, full） |
| **初期状態** | half（50vh） | **peek（120px）** |
| **初期表示** | カード3-4枚 | カード1枚の上部のみ |
| **背景操作（初期）** | 不可（オーバーレイ） | **可能** |
| **情報開示** | 即座に多くの情報 | **段階的な開示** |

## スクリーンショット

（実装内容のため、実機確認推奨）

🤖 Generated with [Claude Code](https://claude.com/claude-code)