### PR TITLE
feat(map): Add bidirectional linking between map and shelter list

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,6 +12,7 @@ export default function HomePage() {
   const { data, isLoading, error } = useShelters();
   const [searchQuery, setSearchQuery] = useState('');
   const [sheetState, setSheetState] = useState<SheetState>('peek');
+  const [selectedShelterId, setSelectedShelterId] = useState<string | null>(null);
 
   // 検索フィルタリング
   const filteredShelters = useMemo(() => {
@@ -75,13 +76,22 @@ export default function HomePage() {
 
         {/* 地図エリア（フルスクリーン） */}
         <div className="flex-1">
-          <ShelterMap shelters={filteredShelters} />
+          <ShelterMap
+            shelters={filteredShelters}
+            selectedShelterId={selectedShelterId}
+            onShelterSelect={setSelectedShelterId}
+          />
         </div>
 
         {/* Bottom Sheet */}
         <BottomSheet state={sheetState} onStateChange={setSheetState}>
           <SheetContent
             shelters={filteredShelters}
+            selectedShelterId={selectedShelterId}
+            onShelterSelect={(id) => {
+              setSelectedShelterId(id);
+              setSheetState('closed'); // カードクリック時に地図を見せる
+            }}
             onMapViewRequest={() => setSheetState('closed')}
           />
         </BottomSheet>
@@ -111,13 +121,21 @@ export default function HomePage() {
 
           {/* 避難所リスト */}
           <div className="min-h-0 flex-1 overflow-y-auto p-4">
-            <ShelterList shelters={filteredShelters} />
+            <ShelterList
+              shelters={filteredShelters}
+              selectedShelterId={selectedShelterId}
+              onShelterSelect={setSelectedShelterId}
+            />
           </div>
         </div>
 
         {/* 地図エリア（右側） */}
         <div className="h-full flex-1">
-          <ShelterMap shelters={filteredShelters} />
+          <ShelterMap
+            shelters={filteredShelters}
+            selectedShelterId={selectedShelterId}
+            onShelterSelect={setSelectedShelterId}
+          />
         </div>
       </div>
     </>

--- a/src/components/mobile/SheetContent.tsx
+++ b/src/components/mobile/SheetContent.tsx
@@ -7,11 +7,15 @@ import { type ViewMode, ViewModeTabs } from './ViewModeTabs';
 
 interface SheetContentProps {
   shelters: ShelterFeature[];
+  selectedShelterId?: string | null | undefined;
+  onShelterSelect?: (id: string) => void;
   onMapViewRequest: () => void;
 }
 
 export function SheetContent({
   shelters,
+  selectedShelterId,
+  onShelterSelect,
   onMapViewRequest,
 }: SheetContentProps) {
   const [viewMode, setViewMode] = useState<ViewMode>('list');
@@ -41,7 +45,11 @@ export function SheetContent({
           aria-labelledby="list-tab"
           className="flex-1 overflow-y-auto p-4"
         >
-          <ShelterList shelters={shelters} />
+          <ShelterList
+            shelters={shelters}
+            selectedShelterId={selectedShelterId}
+            {...(onShelterSelect && { onShelterSelect })}
+          />
         </div>
       )}
 

--- a/src/components/shelter/ShelterCard.tsx
+++ b/src/components/shelter/ShelterCard.tsx
@@ -3,6 +3,7 @@ import { clsx } from 'clsx';
 
 interface ShelterCardProps {
   shelter: ShelterFeature;
+  isSelected?: boolean;
   onClick?: () => void;
 }
 
@@ -19,7 +20,7 @@ function getShelterTypeColor(type: string): string {
   }
 }
 
-export function ShelterCard({ shelter, onClick }: ShelterCardProps) {
+export function ShelterCard({ shelter, isSelected, onClick }: ShelterCardProps) {
   const { name, type, address, disasterTypes, capacity } = shelter.properties;
   const typeColor = getShelterTypeColor(type);
 
@@ -27,7 +28,8 @@ export function ShelterCard({ shelter, onClick }: ShelterCardProps) {
     <div
       className={clsx(
         'cursor-pointer rounded-lg border bg-white p-3 shadow-sm transition-all hover:shadow-md',
-        onClick && 'hover:border-blue-300'
+        onClick && 'hover:border-blue-300',
+        isSelected && 'ring-2 ring-blue-500 bg-blue-50 border-blue-300'
       )}
       onClick={onClick}
       onKeyDown={(e) => {

--- a/src/components/shelter/ShelterList.tsx
+++ b/src/components/shelter/ShelterList.tsx
@@ -3,10 +3,12 @@ import { ShelterCard } from './ShelterCard';
 
 interface ShelterListProps {
   shelters: ShelterFeature[];
+  selectedShelterId?: string | null | undefined;
+  onShelterSelect?: (id: string) => void;
   onShelterClick?: (shelter: ShelterFeature) => void;
 }
 
-export function ShelterList({ shelters, onShelterClick }: ShelterListProps) {
+export function ShelterList({ shelters, selectedShelterId, onShelterSelect, onShelterClick }: ShelterListProps) {
   if (shelters.length === 0) {
     return (
       <div className="flex h-full items-center justify-center p-8 text-center">
@@ -38,7 +40,11 @@ export function ShelterList({ shelters, onShelterClick }: ShelterListProps) {
         <ShelterCard
           key={shelter.properties.id}
           shelter={shelter}
-          onClick={() => onShelterClick?.(shelter)}
+          isSelected={selectedShelterId === shelter.properties.id}
+          onClick={() => {
+            onShelterSelect?.(shelter.properties.id);
+            onShelterClick?.(shelter);
+          }}
         />
       ))}
     </div>


### PR DESCRIPTION
## Summary

Issue #27の実装：避難所リストと地図の双方向連動機能を追加しました。

Fixes #27

## 変更内容

### 機能概要

カードをクリックすると地図が該当位置に移動し、マーカーをクリックするとリスト内のカードがハイライトされます。

### 実装したファイル

**1. `src/app/page.tsx`**
- `selectedShelterId` state追加（共有状態管理）
- ShelterListとShelterMapに状態を渡す
- モバイル: カードクリック時にsheetを'closed'に変更（地図を見せる）

**2. `src/components/shelter/ShelterCard.tsx`**
- `isSelected` props追加
- 選択時のスタイル: `ring-2 ring-blue-500 bg-blue-50 border-blue-300`

**3. `src/components/shelter/ShelterList.tsx`**
- `selectedShelterId`, `onShelterSelect` props追加
- ShelterCardに選択状態とコールバックを渡す

**4. `src/components/mobile/SheetContent.tsx`**
- 選択関連のpropsをShelterListに転送

**5. `src/components/map/ShelterMap.tsx`** (メイン実装)
- `MapController`コンポーネント追加（地図移動制御）
- `selectedShelterId`変更時に`map.flyTo`で滑らかに移動
  - ズーム: 16
  - アニメーション時間: 1000ms
- マーカークリック時に`onShelterSelect`をコール
- 選択中のマーカーを視覚的に強調
  - サイズ: 8px → 10px
  - ボーダー: white → blue-500
  - リング: ring-2 ring-blue-300

## 動作フロー

### フロー1: カードクリック → 地図移動

```
1. ユーザーがリスト内のカードをクリック
   ↓
2. onShelterSelect(id) がコールされる
   ↓
3. page.tsx の selectedShelterId が更新
   ↓
4. ShelterMap の selectedShelterId props が変化
   ↓
5. MapController の useEffect が発火
   ↓
6. map.flyTo() で滑らかに移動（zoom 16, 1s）
   ↓
7. selectedShelter state が更新されてポップアップ表示
   ↓
8. モバイル: sheet が closed に変更（地図が見える）
```

### フロー2: マーカークリック → カードハイライト

```
1. ユーザーが地図上のマーカーをクリック
   ↓
2. handleMarkerClick(shelter) がコールされる
   ↓
3. onShelterSelect(shelter.id) がコールされる
   ↓
4. page.tsx の selectedShelterId が更新
   ↓
5. ShelterCard の isSelected props が true に
   ↓
6. カードが青くハイライト表示
   ↓
7. ポップアップが開く
```

## UI/UX改善

### 視覚的フィードバック

**選択中のカード:**
```tsx
<div
  className={clsx(
    'cursor-pointer rounded-lg border bg-white p-3 shadow-sm',
    isSelected && 'ring-2 ring-blue-500 bg-blue-50 border-blue-300'
  )}
>
```

**選択中のマーカー:**
```tsx
<div
  className={`
    ${isSelected
      ? 'h-10 w-10 border-blue-500 ring-2 ring-blue-300'
      : 'h-8 w-8 border-white'
    }
  `}
>
```

### モバイルUX

- カードクリック時にBottom Sheetを`closed`に変更
- 地図が見えるようになり、選択した避難所の位置を確認できる
- 再度sheetを開けばカードがハイライトされている

### デスクトップUX

- リストと地図が同時に表示されているため、即座に連動
- カードクリック → 地図移動
- マーカークリック → カードハイライト

## テスト方法

### 1. カードクリック → 地図移動

**モバイル:**
1. Bottom Sheetをpeek/half状態にする
2. リスト内のカードをクリック
3. sheetが閉じて地図が表示される
4. 地図が該当位置に滑らかに移動（1秒）
5. ポップアップが開く

**デスクトップ:**
1. 左サイドバーのカードをクリック
2. 右側の地図が該当位置に移動
3. ポップアップが開く

### 2. マーカークリック → カードハイライト

**共通:**
1. 地図上のマーカーをクリック
2. リスト内の該当カードが青くハイライト
3. マーカーが大きくなり青リングが表示
4. ポップアップが開く

### 3. 複数回選択

1. カードAをクリック → 地図移動
2. カードBをクリック → 地図が移動、カードAのハイライト解除
3. マーカーCをクリック → カードCがハイライト、カードBのハイライト解除

## 技術的な実装詳細

### MapController コンポーネント

react-map-glの`useMap`フックを使用して地図インスタンスにアクセス：

```typescript
function MapController({ selectedShelterId, shelters }) {
  const { current: map } = useMap();

  useEffect(() => {
    if (!selectedShelterId || !map) return;

    const shelter = shelters.find(s => s.properties.id === selectedShelterId);
    if (!shelter) return;

    const [lng, lat] = shelter.geometry.coordinates;

    map.flyTo({
      center: [lng, lat],
      zoom: 16,
      duration: 1000,
    });
  }, [selectedShelterId, shelters, map]);

  return null;
}
```

### exactOptionalPropertyTypes対応

TypeScriptの厳格な設定に対応するため、オプショナルpropsに`undefined`を明示：

```typescript
interface MapProps {
  shelters: ShelterFeature[];
  selectedShelterId?: string | null | undefined;  // undefined追加
  onShelterSelect?: (id: string) => void;
}
```

## ビフォー・アフター

| 項目 | Before | After |
|------|--------|-------|
| **カードクリック** | 何も起こらない | 地図移動 + ポップアップ |
| **マーカークリック** | ポップアップのみ | カードハイライト + ポップアップ |
| **選択中の視覚表示** | なし | カード: 青リング、マーカー: 大きく+青リング |
| **モバイルUX** | リストと地図が分断 | カードクリックで地図が見える |
| **デスクトップUX** | リストと地図が独立 | 完全連動 |

## 期待される効果

- ✅ 避難所を探しやすくなる（リスト ⇔ 地図の双方向移動）
- ✅ 視覚的フィードバックで選択中の避難所が明確
- ✅ モバイルでもスムーズに地図とリストを切り替え可能
- ✅ Google Maps風の直感的な操作性

## 参考実装

- Google Maps: リストクリック → 地図移動
- Apple Maps: マーカー選択 → リストハイライト
- Airbnb: 物件選択の双方向連動

🤖 Generated with [Claude Code](https://claude.com/claude-code)