### PR TITLE
fix(ci): Improve Lighthouse workflow trigger conditions

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -3,6 +3,7 @@ name: Lighthouse CI
 on:
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened]
 
 jobs:
   lighthouse:
@@ -33,7 +34,7 @@ jobs:
 
       - name: Comment PR with Lighthouse results
         uses: actions/github-script@v7
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.number
         with:
           script: |
             const fs = require('fs');


### PR DESCRIPTION
## 問題

PR #53のマージ時にLighthouse CIワークフローが失敗しました。

## 原因

ワークフローがイベントのみに設定されているにも関わらず、mainへのpushイベント時にも実行される可能性があり、その場合が存在しないため失敗します。

## 修正内容

1. **PRイベントタイプを明示化**: `opened`, `synchronize`, `reopened`のみに限定
2. **PRコメントステップの条件強化**: `github.event.pull_request.number`の存在チェックを追加

## 効果

- PR時のみLighthouseが実行される
- PRコメント作成時のエラーを防止
- 次回以降のマージでワークフローエラーが発生しない