### PR TITLE
feat(map): Add keyboard accessibility for map markers

### DIFF
--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -149,22 +149,26 @@ export function ShelterMap({
             anchor="bottom"
             onClick={() => handleMarkerClick(shelter)}
           >
-            <div
-              className={`flex cursor-pointer items-center justify-center rounded-full border-2 shadow-lg transition-all hover:scale-110 ${
+            <button
+              type="button"
+              className={`flex cursor-pointer items-center justify-center rounded-full border-2 shadow-lg transition-all hover:scale-110 focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2 ${
                 isSelected
                   ? 'h-10 w-10 border-blue-500 ring-2 ring-blue-300'
                   : 'h-8 w-8 border-white'
               }`}
               style={{ backgroundColor: color }}
+              aria-label={`${shelter.properties.name}（${shelter.properties.type}）`}
+              aria-pressed={isSelected}
             >
               <svg
                 className="h-5 w-5 text-white"
                 fill="currentColor"
                 viewBox="0 0 24 24"
+                aria-hidden="true"
               >
                 <path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z" />
               </svg>
-            </div>
+            </button>
           </Marker>
         );
       }),
@@ -173,6 +177,13 @@ export function ShelterMap({
 
   return (
     <div className="map-container relative h-full w-full">
+      {/* スクリーンリーダー用の説明 */}
+      <div className="sr-only" role="status" aria-live="polite">
+        地図: 鳴門市の避難所を表示しています。
+        矢印キーで地図を移動、+/-キーでズーム、
+        Tabキーで避難所マーカーを選択できます。
+      </div>
+
       <MapGL
         initialViewState={{
           longitude: 134.609,
@@ -197,11 +208,21 @@ export function ShelterMap({
             latitude={position.latitude}
             anchor="center"
           >
-            <div className="relative flex h-6 w-6 items-center justify-center">
+            <div
+              className="relative flex h-6 w-6 items-center justify-center"
+              role="img"
+              aria-label="現在地"
+            >
               {/* 外側のパルスアニメーション */}
-              <div className="absolute h-6 w-6 animate-ping rounded-full bg-blue-400 opacity-75" />
+              <div
+                className="absolute h-6 w-6 animate-ping rounded-full bg-blue-400 opacity-75"
+                aria-hidden="true"
+              />
               {/* 内側の固定円 */}
-              <div className="relative h-4 w-4 rounded-full border-2 border-white bg-blue-500 shadow-lg" />
+              <div
+                className="relative h-4 w-4 rounded-full border-2 border-white bg-blue-500 shadow-lg"
+                aria-hidden="true"
+              />
             </div>
           </Marker>
         )}


### PR DESCRIPTION
## 概要
地図コンポーネントにキーボードアクセシビリティを追加し、WCAG 2.1.1 Keyboard (Level A) 基準に準拠しました。

## 変更内容

### 1. スクリーンリーダー用の説明を追加
- 地図の操作方法をスクリーンリーダーユーザーに案内
- `role="status"` と `aria-live="polite"` でライブリージョンとして実装
- 矢印キー、+/-キー、Tabキーの操作を説明

### 2. マーカーをセマンティックボタンに変更
**Before:**
```tsx
<div className="marker" />
```

**After:**
```tsx
<button
  type="button"
  aria-label={`${shelter.properties.name}（${shelter.properties.type}）`}
  aria-pressed={isSelected}
>
```

### 3. キーボードフォーカススタイルを追加
- `focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2`
- Tabキーでマーカー間を移動可能
- フォーカス時に視覚的なリングを表示

### 4. ARIAラベルの追加
- 避難所マーカー: 施設名と種別を読み上げ
- 現在地マーカー: `role="img" aria-label="現在地"`
- 装飾的SVGに `aria-hidden="true"` を付与

## WCAG準拠

- ✅ **WCAG 2.1.1 Keyboard (Level A)**: すべての機能がキーボードのみで操作可能
- ✅ **WCAG 4.1.2 Name, Role, Value (Level A)**: すべてのマーカーに適切なラベルとロールを設定
- ✅ **WCAG 2.4.7 Focus Visible (Level AA)**: フォーカス時に明確な視覚的インジケーター

## テスト項目

- [x] Tabキーでマーカー間を移動できる
- [x] Enterキーまたはスペースキーでマーカーを選択できる
- [x] フォーカス時に視覚的なリングが表示される
- [x] スクリーンリーダーで操作説明が読み上げられる
- [x] マーカーの施設名と種別が読み上げられる
- [x] ビルドとTypeチェックが通過

## スクリーンショット
（キーボードフォーカス時のリング表示）

## 関連Issue
Closes #81

## チェックリスト
- [x] コードがBiomeのルールに準拠している
- [x] TypeScriptの型チェックが通る
- [x] ビルドが成功する
- [x] WCAG 2.1.1準拠を確認
- [x] コミットメッセージがConventional Commits形式

---

Part of Phase 7: UX/UI改善・アクセシビリティ強化 (#73)