### PR TITLE
feat(a11y): Add shelter type icons for color-independent identification

### DIFF
--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -12,6 +12,7 @@ import type {
   GeolocationError,
   GeolocationState,
 } from '@/hooks/useGeolocation';
+import { getShelterIcon } from '@/lib/shelterIcons';
 import type { ShelterFeature } from '@/types/shelter';
 import { CurrentLocationButton } from './CurrentLocationButton';
 import 'maplibre-gl/dist/maplibre-gl.css';
@@ -160,14 +161,9 @@ export function ShelterMap({
               aria-label={`${shelter.properties.name}（${shelter.properties.type}）`}
               aria-pressed={isSelected}
             >
-              <svg
-                className="h-5 w-5 text-white"
-                fill="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z" />
-              </svg>
+              {getShelterIcon(shelter.properties.type, {
+                className: 'h-5 w-5 text-white',
+              })}
             </button>
           </Marker>
         );

--- a/src/components/shelter/ShelterCard.tsx
+++ b/src/components/shelter/ShelterCard.tsx
@@ -1,5 +1,6 @@
 import { clsx } from 'clsx';
 import { formatDistance } from '@/lib/geo';
+import { getShelterIcon } from '@/lib/shelterIcons';
 import type { ShelterFeature } from '@/types/shelter';
 
 interface ShelterCardProps {
@@ -50,11 +51,12 @@ export function ShelterCard({
         </h3>
         <span
           className={clsx(
-            'rounded-full border px-2 py-0.5 text-xs font-medium whitespace-nowrap',
+            'inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium whitespace-nowrap',
             typeColor
           )}
         >
-          {type}
+          {getShelterIcon(type, { className: 'h-3.5 w-3.5' })}
+          <span>{type}</span>
         </span>
       </div>
 

--- a/src/lib/shelterIcons.tsx
+++ b/src/lib/shelterIcons.tsx
@@ -1,0 +1,91 @@
+import type { FC, ReactElement, SVGProps } from 'react';
+
+/**
+ * 避難所タイプ別アイコンコンポーネント
+ *
+ * WCAG 1.4.1 Use of Color (Level A) に対応
+ * 色だけでなくアイコンでも避難所タイプを識別可能にする
+ *
+ * @see https://www.w3.org/WAI/WCAG21/Understanding/use-of-color.html
+ */
+
+interface ShelterIconProps extends SVGProps<SVGSVGElement> {
+  className?: string;
+}
+
+/**
+ * 指定避難所アイコン（家）
+ */
+export const DesignatedShelterIcon: FC<ShelterIconProps> = ({
+  className = 'h-4 w-4',
+  ...props
+}) => (
+  <svg
+    className={className}
+    fill="currentColor"
+    viewBox="0 0 20 20"
+    aria-hidden="true"
+    {...props}
+  >
+    <path d="M10.707 2.293a1 1 0 00-1.414 0l-7 7a1 1 0 001.414 1.414L4 10.414V17a1 1 0 001 1h2a1 1 0 001-1v-2a1 1 0 011-1h2a1 1 0 011 1v2a1 1 0 001 1h2a1 1 0 001-1v-6.586l.293.293a1 1 0 001.414-1.414l-7-7z" />
+  </svg>
+);
+
+/**
+ * 緊急避難場所アイコン（警告）
+ */
+export const EmergencyShelterIcon: FC<ShelterIconProps> = ({
+  className = 'h-4 w-4',
+  ...props
+}) => (
+  <svg
+    className={className}
+    fill="currentColor"
+    viewBox="0 0 20 20"
+    aria-hidden="true"
+    {...props}
+  >
+    <path
+      fillRule="evenodd"
+      d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z"
+      clipRule="evenodd"
+    />
+  </svg>
+);
+
+/**
+ * 両方（指定避難所 + 緊急避難場所）アイコン（星）
+ */
+export const BothShelterIcon: FC<ShelterIconProps> = ({
+  className = 'h-4 w-4',
+  ...props
+}) => (
+  <svg
+    className={className}
+    fill="currentColor"
+    viewBox="0 0 20 20"
+    aria-hidden="true"
+    {...props}
+  >
+    <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+  </svg>
+);
+
+/**
+ * 避難所タイプに応じたアイコンを返すヘルパー関数
+ */
+export function getShelterIcon(
+  type: string,
+  props?: ShelterIconProps
+): ReactElement {
+  switch (type) {
+    case '指定避難所':
+      return <DesignatedShelterIcon {...props} />;
+    case '緊急避難場所':
+      return <EmergencyShelterIcon {...props} />;
+    case '両方':
+      return <BothShelterIcon {...props} />;
+    default:
+      return <DesignatedShelterIcon {...props} />;
+  }
+}


### PR DESCRIPTION
## 概要
避難所タイプの識別を色だけでなくアイコンでも可能にし、WCAG 1.4.1 Use of Color (Level A) 基準に準拠しました。

## 変更内容

### 1. 避難所タイプ別アイコンライブラリを作成
**新規ファイル:** `src/lib/shelterIcons.tsx`

各避難所タイプに固有のアイコンを定義:
- **指定避難所**: 家アイコン (DesignatedShelterIcon)
- **緊急避難場所**: 警告アイコン (EmergencyShelterIcon)
- **両方**: 星アイコン (BothShelterIcon)

### 2. ShelterCardにアイコンを追加
**ファイル:** `src/components/shelter/ShelterCard.tsx`

**Before:**
```tsx
<span className={typeColor}>
  {type}
</span>
```

**After:**
```tsx
<span className={typeColor}>
  {getShelterIcon(type, { className: 'h-3.5 w-3.5' })}
  <span>{type}</span>
</span>
```

### 3. 地図マーカーをタイプ別アイコンに変更
**ファイル:** `src/components/map/Map.tsx`

**Before:**
```tsx
<svg>
  <path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13..." /> {/* 汎用ピンアイコン */}
</svg>
```

**After:**
```tsx
{getShelterIcon(shelter.properties.type, {
  className: 'h-5 w-5 text-white',
})}
```

## WCAG準拠

- ✅ **WCAG 1.4.1 Use of Color (Level A)**: 色だけでなくアイコンでも識別可能
- ✅ 色覚多様性のあるユーザーでも避難所タイプを区別できる
- ✅ グレースケール表示でもタイプが識別可能

## 実装詳細

### アイコンの選択理由
- **指定避難所（家）**: 長期滞在可能な施設のイメージ
- **緊急避難場所（警告）**: 緊急時の一時避難のイメージ
- **両方（星）**: 両機能を持つ重要な施設のイメージ

### アクセシビリティ対応
- すべてのアイコンに `aria-hidden="true"` を付与（装飾的要素として扱う）
- テキストラベルは別途提供されているため、アイコンは視覚的補助として機能
- キーボードナビゲーション・スクリーンリーダーには影響しない

## テスト項目

- [x] 避難所カードにアイコンが表示される
- [x] 地図マーカーにタイプ別アイコンが表示される
- [x] 色とアイコンの両方で識別可能
- [x] TypeScriptの型チェックが通る
- [x] ビルドが成功する
- [ ] 色覚シミュレーターでテスト（手動確認推奨）

## スクリーンショット
（マーカーとカードにアイコンが表示される様子）

## 関連Issue
Closes #82

## チェックリスト
- [x] コードがBiomeのルールに準拠している
- [x] TypeScriptの型チェックが通る
- [x] ビルドが成功する
- [x] WCAG 1.4.1準拠を確認
- [x] コミットメッセージがConventional Commits形式

---

Part of Phase 7: UX/UI改善・アクセシビリティ強化 (#73)