### PR TITLE
feat(a11y): Add accessible link styling with underlines

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -22,6 +22,19 @@
     @apply dark:bg-gray-900 dark:text-gray-100;
   }
 
+  /* リンクのデフォルトスタイル */
+  a:not(.skip-link):not([class*='maplibre']) {
+    @apply underline underline-offset-2;
+    @apply text-blue-600 hover:text-blue-700;
+    @apply dark:text-blue-400 dark:hover:text-blue-300;
+  }
+
+  /* リンクのフォーカススタイル */
+  a:focus-visible {
+    @apply outline-none ring-2 ring-blue-500 ring-offset-2;
+    @apply dark:ring-blue-400 dark:ring-offset-gray-900;
+  }
+
   /* 地図コンテナのCLS対策 */
   .map-container {
     contain: layout style paint;


### PR DESCRIPTION
## 概要
リンクを色だけでなく下線でも識別可能にし、WCAG 1.4.1 Use of Color (Level A) 基準に準拠しました。

## 変更内容

### リンクのベーススタイル設定
**ファイル:** `src/app/globals.css`

```css
/* リンクのデフォルトスタイル */
a:not(.skip-link):not([class*='maplibre']) {
  @apply underline underline-offset-2;
  @apply text-blue-600 hover:text-blue-700;
  @apply dark:text-blue-400 dark:hover:text-blue-300;
}

/* リンクのフォーカススタイル */
a:focus-visible {
  @apply outline-none ring-2 ring-blue-500 ring-offset-2;
  @apply dark:ring-blue-400 dark:ring-offset-gray-900;
}
```

## 実装詳細

### スタイル適用の除外
- `.skip-link`: スキップリンクは専用スタイルを維持
- `[class*='maplibre']`: MapLibreコントロールのリンクは除外

### カラー設定

| 状態 | ライトモード | ダークモード | コントラスト比 |
|------|------------|------------|---------------|
| デフォルト | `text-blue-600` | `text-blue-400` | 4.5:1以上 ✅ |
| ホバー | `text-blue-700` | `text-blue-300` | 4.5:1以上 ✅ |

### アクセシビリティ機能
1. **下線**: `underline underline-offset-2` で常時表示
2. **色の変化**: ホバー時に色が変わる（視覚的フィードバック）
3. **フォーカスリング**: キーボードナビゲーション時にリングを表示

## WCAG準拠

- ✅ **WCAG 1.4.1 Use of Color (Level A)**: 色だけでなく下線でも識別可能
- ✅ **WCAG 2.4.7 Focus Visible (Level AA)**: キーボードフォーカス時に明確なリング表示
- ✅ **WCAG 1.4.3 Contrast (Level AA)**: すべての色が4.5:1以上のコントラスト比

## 現在のリンク使用状況

現時点でプロジェクトには以下のリンクがあります：
- `SkipLink`: アクセシビリティ用スキップリンク（専用スタイル維持）
- MapLibreコントロール: 地図ライブラリのコントロール（除外）

将来的に追加されるリンク（外部リンク、フッターリンクなど）は自動的にこのスタイルが適用されます。

## テスト項目

- [x] TypeScriptの型チェックが通る
- [x] ビルドが成功する
- [x] SkipLinkのスタイルが変わらない
- [x] MapLibreコントロールが影響を受けない
- [ ] 実際のリンク追加時の動作確認（将来）

## 関連Issue
Closes #85

## チェックリスト
- [x] コードがBiomeのルールに準拠している
- [x] TypeScriptの型チェックが通る
- [x] ビルドが成功する
- [x] WCAG 1.4.1準拠を確認
- [x] コミットメッセージがConventional Commits形式

---

Part of Phase 7: UX/UI改善・アクセシビリティ強化 (#73)