### PR TITLE
feat: Add route navigation to shelters

### DIFF
--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -12,6 +12,7 @@ import type {
   GeolocationError,
   GeolocationState,
 } from '@/hooks/useGeolocation';
+import { generateNavigationURL } from '@/lib/navigation';
 import { getShelterIcon } from '@/lib/shelterIcons';
 import type { ShelterFeature } from '@/types/shelter';
 import { CurrentLocationButton } from './CurrentLocationButton';
@@ -233,11 +234,11 @@ export function ShelterMap({
             closeOnClick={false}
             className="shelter-popup"
           >
-            <div className="p-2">
+            <div className="p-3">
               <h3 className="mb-2 font-bold text-gray-900 dark:text-gray-100">
                 {selectedShelter.properties.name}
               </h3>
-              <div className="space-y-1 text-sm text-gray-700 dark:text-gray-300">
+              <div className="space-y-1 text-sm text-gray-700 dark:text-gray-300 mb-3">
                 <p>
                   <span className="font-semibold">種別:</span>{' '}
                   {selectedShelter.properties.type}
@@ -257,6 +258,36 @@ export function ShelterMap({
                   </p>
                 )}
               </div>
+              <button
+                type="button"
+                onClick={() => {
+                  const [lng, lat] = selectedShelter.geometry.coordinates;
+                  const url = generateNavigationURL(
+                    { latitude: lat, longitude: lng },
+                    undefined,
+                    'walking'
+                  );
+                  window.open(url, '_blank', 'noopener,noreferrer');
+                }}
+                className="w-full flex items-center justify-center gap-2 px-3 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 rounded-md transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2"
+                aria-label={`${selectedShelter.properties.name}への経路案内`}
+              >
+                <svg
+                  className="h-5 w-5"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l4.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-.553-.894L15 4m0 13V4m0 0L9 7"
+                  />
+                </svg>
+                <span>経路案内を開く</span>
+              </button>
             </div>
           </Popup>
         )}

--- a/src/components/shelter/ShelterCard.tsx
+++ b/src/components/shelter/ShelterCard.tsx
@@ -1,5 +1,11 @@
 import { clsx } from 'clsx';
 import { formatDistance } from '@/lib/geo';
+import {
+  estimateDrivingTime,
+  estimateWalkingTime,
+  formatTravelTime,
+  generateNavigationURL,
+} from '@/lib/navigation';
 import { getShelterIcon } from '@/lib/shelterIcons';
 import type { ShelterFeature } from '@/types/shelter';
 
@@ -154,7 +160,7 @@ export function ShelterCard({
       )}
 
       {/* 追加情報（コンパクトに1行で表示） */}
-      <div className="flex items-center gap-3 text-xs text-gray-700 dark:text-gray-300">
+      <div className="flex items-center gap-3 text-xs text-gray-700 dark:text-gray-300 mb-2">
         {/* 災害種別 */}
         <span className="flex items-center gap-1">
           <svg
@@ -195,6 +201,58 @@ export function ShelterCard({
           </span>
         )}
       </div>
+
+      {/* 経路案内ボタン（距離がある場合のみ） */}
+      {distance !== null && distance !== undefined && (
+        <div className="flex items-center gap-2 pt-2 border-t border-gray-200 dark:border-gray-700">
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              const [lng, lat] = shelter.geometry.coordinates;
+              const url = generateNavigationURL(
+                { latitude: lat, longitude: lng },
+                undefined,
+                'walking'
+              );
+              window.open(url, '_blank', 'noopener,noreferrer');
+            }}
+            className="flex-1 flex items-center justify-center gap-1.5 px-3 py-1.5 text-xs font-medium text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/20 rounded-md hover:bg-blue-100 dark:hover:bg-blue-900/30 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
+            aria-label={`${name}への経路案内`}
+          >
+            <svg
+              className="h-4 w-4"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l4.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-.553-.894L15 4m0 13V4m0 0L9 7"
+              />
+            </svg>
+            <span className="truncate">経路案内</span>
+          </button>
+          <div className="flex items-center gap-2 text-xs text-gray-600 dark:text-gray-400">
+            <span
+              className="whitespace-nowrap"
+              title={`徒歩: ${formatTravelTime(estimateWalkingTime(distance))}`}
+            >
+              🚶 {formatTravelTime(estimateWalkingTime(distance))}
+            </span>
+            <span className="text-gray-400 dark:text-gray-600">|</span>
+            <span
+              className="whitespace-nowrap"
+              title={`車: ${formatTravelTime(estimateDrivingTime(distance))}`}
+            >
+              🚗 {formatTravelTime(estimateDrivingTime(distance))}
+            </span>
+          </div>
+        </div>
+      )}
     </button>
   );
 }

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -1,0 +1,131 @@
+/**
+ * 経路案内URLを生成するユーティリティ関数
+ *
+ * Google MapsとApple Mapsへのディープリンクを生成します
+ */
+
+export interface NavigationCoordinates {
+  latitude: number;
+  longitude: number;
+}
+
+export type MapProvider = 'google' | 'apple';
+
+/**
+ * デバイスのプラットフォームを判定
+ */
+export function detectPlatform(): MapProvider {
+  if (typeof window === 'undefined') {
+    return 'google';
+  }
+
+  const userAgent = window.navigator.userAgent.toLowerCase();
+  const isIOS =
+    /iphone|ipad|ipod/.test(userAgent) ||
+    (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+
+  return isIOS ? 'apple' : 'google';
+}
+
+/**
+ * Google MapsのURL生成
+ *
+ * @param destination 目的地の座標
+ * @param travelMode 移動手段（walking: 徒歩, driving: 車）
+ * @returns Google Maps URL
+ */
+export function generateGoogleMapsURL(
+  destination: NavigationCoordinates,
+  travelMode: 'walking' | 'driving' = 'walking'
+): string {
+  const { latitude, longitude } = destination;
+  const baseURL = 'https://www.google.com/maps/dir/?api=1';
+  const params = new URLSearchParams({
+    destination: `${latitude},${longitude}`,
+    travelmode: travelMode,
+  });
+
+  return `${baseURL}&${params.toString()}`;
+}
+
+/**
+ * Apple MapsのURL生成
+ *
+ * @param destination 目的地の座標
+ * @returns Apple Maps URL
+ */
+export function generateAppleMapsURL(
+  destination: NavigationCoordinates
+): string {
+  const { latitude, longitude } = destination;
+  return `maps://?daddr=${latitude},${longitude}`;
+}
+
+/**
+ * プラットフォームに応じた経路案内URLを生成
+ *
+ * @param destination 目的地の座標
+ * @param provider マッププロバイダー（省略時は自動判定）
+ * @param travelMode 移動手段（Google Mapsのみ有効）
+ * @returns 経路案内URL
+ */
+export function generateNavigationURL(
+  destination: NavigationCoordinates,
+  provider?: MapProvider,
+  travelMode: 'walking' | 'driving' = 'walking'
+): string {
+  const mapProvider = provider ?? detectPlatform();
+
+  if (mapProvider === 'apple') {
+    return generateAppleMapsURL(destination);
+  }
+
+  return generateGoogleMapsURL(destination, travelMode);
+}
+
+/**
+ * 距離（メートル）から徒歩での所要時間を推定
+ *
+ * @param distanceInMeters 距離（メートル）
+ * @returns 所要時間（分）
+ */
+export function estimateWalkingTime(distanceInMeters: number): number {
+  const WALKING_SPEED_KM_PER_HOUR = 4; // 徒歩速度: 4km/h
+  const distanceInKm = distanceInMeters / 1000;
+  const timeInHours = distanceInKm / WALKING_SPEED_KM_PER_HOUR;
+  return Math.round(timeInHours * 60); // 分単位に変換
+}
+
+/**
+ * 距離（メートル）から車での所要時間を推定
+ *
+ * @param distanceInMeters 距離（メートル）
+ * @returns 所要時間（分）
+ */
+export function estimateDrivingTime(distanceInMeters: number): number {
+  const DRIVING_SPEED_KM_PER_HOUR = 30; // 市街地平均速度: 30km/h
+  const distanceInKm = distanceInMeters / 1000;
+  const timeInHours = distanceInKm / DRIVING_SPEED_KM_PER_HOUR;
+  return Math.round(timeInHours * 60); // 分単位に変換
+}
+
+/**
+ * 所要時間を読みやすい形式でフォーマット
+ *
+ * @param minutes 所要時間（分）
+ * @returns フォーマットされた文字列（例: "15分", "1時間30分"）
+ */
+export function formatTravelTime(minutes: number): string {
+  if (minutes < 60) {
+    return `${minutes}分`;
+  }
+
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+
+  if (remainingMinutes === 0) {
+    return `${hours}時間`;
+  }
+
+  return `${hours}時間${remainingMinutes}分`;
+}


### PR DESCRIPTION
## 概要
Phase 8.1のルート案内機能を実装しました。

## 実装内容

### 新規ファイル
- **`src/lib/navigation.ts`** - 経路案内ユーティリティ関数
  - Google Maps / Apple Maps URL生成
  - プラットフォーム自動判定（iOS → Apple Maps, Android/その他 → Google Maps）
  - 徒歩・車での所要時間推定
  - 所要時間のフォーマット表示

### 変更ファイル
- **`src/components/shelter/ShelterCard.tsx`**
  - 経路案内ボタン追加（距離表示がある場合のみ）
  - 徒歩・車の所要時間表示（🚶15分 | 🚗5分）
  - クリックでマップアプリ起動
  - イベント伝播防止（e.stopPropagation）

- **`src/components/map/Map.tsx`**
  - Popupに経路案内ボタン追加
  - 目立つプライマリーボタンデザイン

## 主な機能

✅ **プラットフォーム別URL生成**
- iOS: `maps://?daddr=LAT,LNG` (Apple Maps)
- Android: `https://www.google.com/maps/dir/?api=1&destination=LAT,LNG` (Google Maps)

✅ **所要時間推定**
- 徒歩: 4km/h
- 車: 30km/h（市街地平均速度）

✅ **ユーザビリティ**
- ワンクリックでマップアプリ起動
- 外部リンクはnoopener/noreferrer付き
- キーボードアクセシビリティ対応
- ダークモード対応

## UI例

### ShelterCard
```
━━━━━━━━━━━━━━━━━━━━
[避難所名]  [❤️] [指定避難所]
━━━━━━━━━━━━━━━━━━━━
📍 鳴門市撫養町...
距離: 1.2km
━━━━━━━━━━━━━━━━━━━━
⚠️ 地震・津波  👥 500人
━━━━━━━━━━━━━━━━━━━━
[🗺️ 経路案内]  🚶15分 | 🚗5分
━━━━━━━━━━━━━━━━━━━━
```

### Map Popup
```
━━━━━━━━━━━━━━━━
鳴門市役所      [×]
━━━━━━━━━━━━━━━━
種別: 指定避難所
住所: 徳島県...
災害種別: 地震・津波
収容人数: 500人
━━━━━━━━━━━━━━━━
[🗺️ 経路案内を開く]
━━━━━━━━━━━━━━━━
```

## テスト

- [x] ビルド成功
- [x] 型チェック成功
- [x] Lint成功（既存warningのみ）
- [x] デスクトップで動作確認
- [x] モバイルシミュレータで確認

## 技術仕様

### URL Schemes

**Google Maps:**
```typescript
https://www.google.com/maps/dir/?api=1&destination=34.173,134.609&travelmode=walking
```

**Apple Maps:**
```typescript
maps://?daddr=34.173,134.609
```

### 所要時間計算
```typescript
徒歩: (距離 / 4km/h) * 60 分
車:   (距離 / 30km/h) * 60 分
```

## 今後の拡張

- [ ] 複数経路の比較表示
- [ ] リアルタイム交通情報統合
- [ ] 公共交通機関のルート表示

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>