### PR TITLE
feat(map): Add marker clustering with Supercluster

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,14 +29,17 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-map-gl": "^8.0.0",
+    "supercluster": "^8.0.1",
     "tailwind-merge": "^3.3.1"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.2",
     "@tailwindcss/postcss": "^4.1.16",
+    "@types/geojson": "^7946.0.16",
     "@types/node": "^24.9.2",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
+    "@types/supercluster": "^7.1.3",
     "tailwindcss": "^4.1.16",
     "tsx": "^4.20.6",
     "typescript": "^5.6.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       react-map-gl:
         specifier: ^8.0.0
         version: 8.1.0(maplibre-gl@5.10.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      supercluster:
+        specifier: ^8.0.1
+        version: 8.0.1
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.3.1
@@ -42,6 +45,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4.1.16
         version: 4.1.16
+      '@types/geojson':
+        specifier: ^7946.0.16
+        version: 7946.0.16
       '@types/node':
         specifier: ^24.9.2
         version: 24.9.2
@@ -51,6 +57,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.0.0
         version: 19.2.2(@types/react@19.2.2)
+      '@types/supercluster':
+        specifier: ^7.1.3
+        version: 7.1.3
       tailwindcss:
         specifier: ^4.1.16
         version: 4.1.16

--- a/src/hooks/useClustering.ts
+++ b/src/hooks/useClustering.ts
@@ -1,0 +1,114 @@
+'use client';
+
+import type { BBox } from 'geojson';
+import { useMemo } from 'react';
+import Supercluster from 'supercluster';
+import type { ShelterFeature } from '@/types/shelter';
+
+interface ClusterProperties {
+  cluster?: boolean;
+  cluster_id?: number;
+  point_count?: number;
+  point_count_abbreviated?: string;
+  shelterId?: string;
+  shelterName?: string;
+  shelterType?: string;
+}
+
+type ClusterFeature = Supercluster.ClusterFeature<ClusterProperties>;
+type PointFeature = Supercluster.PointFeature<ClusterProperties>;
+
+interface UseClusteringParams {
+  shelters: ShelterFeature[];
+  zoom: number;
+  bounds: BBox;
+  enabled?: boolean;
+}
+
+interface UseClusteringReturn {
+  clusters: Array<ClusterFeature | PointFeature>;
+  supercluster: Supercluster | null;
+}
+
+/**
+ * マーカークラスタリング管理フック
+ *
+ * Superclusterを使用して避難所マーカーをクラスタリングします。
+ * ズームレベルと表示領域に応じて動的にクラスタを生成します。
+ *
+ * @param shelters - 避難所データ配列
+ * @param zoom - 現在の地図ズームレベル
+ * @param bounds - 現在の地図表示領域 [west, south, east, north]
+ * @param enabled - クラスタリング有効/無効（デフォルト: true）
+ * @returns クラスタ配列とSuperclusterインスタンス
+ */
+export function useClustering({
+  shelters,
+  zoom,
+  bounds,
+  enabled = true,
+}: UseClusteringParams): UseClusteringReturn {
+  // Superclusterインスタンスをメモ化（sheltersが変更されたときのみ再生成）
+  const supercluster = useMemo(() => {
+    if (!enabled || shelters.length === 0) return null;
+
+    // Supercluster初期化
+    const cluster = new Supercluster<ClusterProperties, ClusterProperties>({
+      radius: 60, // クラスタ半径（ピクセル）
+      maxZoom: 16, // クラスタリング最大ズーム（これ以上ズームするとクラスタ解除）
+      minZoom: 0, // クラスタリング最小ズーム
+      minPoints: 2, // クラスタを形成する最小ポイント数
+    });
+
+    // 避難所データをSupercluster形式に変換
+    const points: Array<PointFeature> = shelters.map((shelter) => ({
+      type: 'Feature',
+      properties: {
+        cluster: false,
+        shelterId: shelter.properties.id,
+        shelterName: shelter.properties.name,
+        shelterType: shelter.properties.type,
+      },
+      geometry: {
+        type: 'Point',
+        coordinates: shelter.geometry.coordinates,
+      },
+    }));
+
+    // データをロード
+    cluster.load(points);
+
+    return cluster;
+  }, [shelters, enabled]);
+
+  // ズームレベルと表示領域に応じたクラスタを取得（メモ化）
+  const clusters = useMemo(() => {
+    if (!supercluster) {
+      // クラスタリング無効時は元のデータをそのまま返す
+      return shelters.map((shelter) => ({
+        type: 'Feature' as const,
+        properties: {
+          cluster: false,
+          shelterId: shelter.properties.id,
+          shelterName: shelter.properties.name,
+          shelterType: shelter.properties.type,
+        },
+        geometry: {
+          type: 'Point' as const,
+          coordinates: shelter.geometry.coordinates,
+        },
+      }));
+    }
+
+    // 整数ズームレベルに丸める（Superclusterの要件）
+    const intZoom = Math.floor(zoom);
+
+    // 表示領域内のクラスタを取得
+    return supercluster.getClusters(bounds, intZoom);
+  }, [supercluster, zoom, bounds, shelters]);
+
+  return {
+    clusters,
+    supercluster,
+  };
+}


### PR DESCRIPTION
## Summary

Implements **Phase 2** of Issue #98: マーカークラスタリング機能を追加しました。

Superclusterライブラリを使用して、多数の避難所マーカーが表示される際のパフォーマンスと視認性を改善します。

## Changes

### Dependencies
- ✅ `supercluster ^8.0.1` - クラスタリングライブラリ
- ✅ `@types/supercluster ^7.1.3` - TypeScript型定義
- ✅ `@types/geojson ^7946.0.16` - GeoJSON型サポート

### New Files
- ✅ `src/hooks/useClustering.ts` - クラスタリング状態管理フック
  - Supercluster初期化と設定
  - ズームレベルと表示領域に基づく動的クラスタ生成
  - パフォーマンス最適化のためのメモ化

### Modified Files
- ✅ `src/components/map/Map.tsx`
  - クラスタリングフックの統合
  - ズームレベルと表示領域の追跡
  - クラスター対応マーカーレンダリング
  - クラスター展開のクリックハンドラ
- ✅ `src/components/map/MapStyleSwitcher.tsx` - Import順序の最適化

## Features

### Clustering Behavior
- 🔄 ズームレベルに応じた動的クラスタリング
  - **最大ズーム**: 16 (これ以上ズームするとクラスタ解除)
  - **クラスタ半径**: 60ピクセル
  - **最小ポイント数**: 2 (クラスタ形成に必要)

- 🎯 クラスターUIの特徴
  - **紫色の円形マーカー** (個別マーカーとの視覚的差別化)
  - **ポイント数の表示** (中央に数字)
  - **動的サイジング**: ポイント数に応じてサイズが拡大
  - **クリック可能**: クラスターをクリックすると展開ズームレベルまでズームイン

### Performance Improvements
- ⚡ 大量マーカー表示時のレンダリング最適化
- 🧮 useMemoによる計算結果のキャッシング
- 🎨 レスポンシブなクラスター再計算

### Accessibility
- ♿ `aria-label`でクラスター内のポイント数を通知
- ⌨️ キーボード操作対応
- 🎨 ホバー・フォーカス時のビジュアルフィードバック

## Testing

### Type Safety
```bash
pnpm type-check  # ✅ Passed
```

### Linting
```bash
pnpm lint:fix    # ✅ Fixed import ordering
```

### Build
```bash
pnpm build       # ✅ Production build successful
```

## Screenshots

クラスタリング動作の確認スクリーンショットは、マージ前にレビュー時に追加予定です。

### Low Zoom (Clustered View)
- 複数の避難所が紫色のクラスターマーカーにグループ化
- クラスター内のマーカー数を表示

### High Zoom (Individual Markers)
- ズームレベル16以上でクラスター解除
- 個別の避難所マーカー(青/赤/紫)が表示
- 既存の選択・インタラクション機能を維持

## Remaining Work (Phase 3)

次のフェーズ (#98 Phase 3) で実装予定:
- 🗺️ **ヒートマップ表示**: 避難所密集度の可視化
- 🌐 **3Dグローブ投影**: 立体的な地図表示
- ⚡ **パフォーマンス最適化**: さらなる高速化

## Related

- Closes #98 (Phase 2: Marker Clustering)
- Depends on: #118 (Map Style Switcher - merged)

## Checklist

- [x] TypeScript型チェック通過
- [x] Biome lintルール準拠
- [x] Production buildエラーなし
- [x] アクセシビリティ対応
- [x] レスポンシブデザイン
- [x] Conventional Commits準拠

🤖 Generated with [Claude Code](https://claude.com/claude-code)