### PR TITLE
fix: Regenerate pnpm-lock.yaml to resolve broken lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4902,7 +4902,7 @@ snapshots:
     dependencies:
       '@next/env': 16.0.3
       '@swc/helpers': 0.5.15
-      caniuse-lite: 1.0.30001753
+      caniuse-lite: 1.0.30001754
       postcss: 8.4.31
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)


### PR DESCRIPTION
## Summary
CIが失敗していた原因を修正しました。マージコンフリクトの解決時にが壊れていたため、ロックファイルを再生成しました。

## Problem
- `ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY`: `caniuse-lite@1.0.30001753`のエントリが欠落
- マージコンフリクトの解決時にロックファイルが正しく更新されなかった

## Solution
- `pnpm install --no-frozen-lockfile`を実行してロックファイルを再生成

## Testing
- ✅ ローカルで`pnpm install --frozen-lockfile`が成功
- ✅ ビルドが正常に完了

🤖 Generated with Claude Code