### PR TITLE
fix(map): Move NavigationControl to top-left to avoid overlap

### DIFF
--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -305,7 +305,7 @@ export function ShelterMap({
           selectedShelterId={selectedShelterId}
           shelters={shelters}
         />
-        <NavigationControl position="top-right" />
+        <NavigationControl position="top-left" />
 
         {markers}
 


### PR DESCRIPTION
## Summary
地図スタイル切り替えボタンとズームコントロール（NavigationControl）が重なっていた問題を修正しました。

## Problem
- NavigationControlが`top-right`に配置されていた
- 地図スタイル切り替えボタンも右上（`top-4 right-4`）に配置されていた
- 2つのUI要素が重なって操作しづらかった

## Solution
- NavigationControlの位置を`top-left`に変更
- これにより、ズームコントロールは左上、地図スタイル切り替えは右上に配置され、重ならなくなる

## Testing
- ✅ ズームコントロールが左上に表示される
- ✅ 地図スタイル切り替えボタンが右上に表示される
- ✅ 2つのUI要素が重ならない

Closes #131

🤖 Generated with Claude Code