### PR TITLE
fix(map): Adjust search bar position to avoid overlap with NavigationControl

### DIFF
--- a/src/components/map/MapSearchBar.tsx
+++ b/src/components/map/MapSearchBar.tsx
@@ -35,7 +35,7 @@ export const MapSearchBar: FC<MapSearchBarProps> = ({
   return (
     <div
       className={`
-        absolute left-4 right-4 top-4 z-20
+        absolute left-14 right-4 top-4 z-20
         lg:left-1/2 lg:right-auto lg:w-[600px] lg:-translate-x-1/2
       `}
     >


### PR DESCRIPTION
## Summary
モバイル表示で検索バーとNavigationControl（ズームコントロール）が左上で重なっていた問題を修正しました。

## Problem
- 検索バーが `left-4` (16px) から始まっていた
- NavigationControlが左上（10px, 10px）に配置されている
- モバイル表示で検索バーの左端がNavigationControlと重なっていた

## Solution
- 検索バーの左マージンを `left-4` (16px) から `left-14` (56px) に変更
- NavigationControlの幅（約29px）+ マージン（16px）+ 余白（11px）= 56px を確保
- デスクトップ表示（`lg:`）は変更なし（中央配置のまま）

## Testing
- ✅ モバイル表示で検索バーとNavigationControlが重ならない
- ✅ デスクトップ表示は中央配置のまま
- ✅ 検索機能は正常に動作

🤖 Generated with Claude Code