### PR TITLE
feat(pwa): Phase 6 - PWA対応・オフライン強化

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.2/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.3.4/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/next.config.js
+++ b/next.config.js
@@ -1,14 +1,14 @@
-const withPWA = require('@ducanh2912/next-pwa').default({
-  dest: 'public',
+const withPWA = require("@ducanh2912/next-pwa").default({
+  dest: "public",
   register: true,
   skipWaiting: true,
-  disable: process.env.NODE_ENV === 'development',
+  disable: process.env.NODE_ENV === "development",
   runtimeCaching: [
     {
       urlPattern: /^https:\/\/tile\.openstreetmap\.jp\/.*/i,
-      handler: 'CacheFirst',
+      handler: "CacheFirst",
       options: {
-        cacheName: 'osm-tiles',
+        cacheName: "osm-tiles",
         expiration: {
           maxEntries: 500,
           maxAgeSeconds: 60 * 60 * 24 * 30, // 30日
@@ -16,10 +16,21 @@ const withPWA = require('@ducanh2912/next-pwa').default({
       },
     },
     {
-      urlPattern: /\.(?:png|jpg|jpeg|svg|gif|webp)$/i,
-      handler: 'CacheFirst',
+      urlPattern: /^https:\/\/api\.maptiler\.com\/.*/i,
+      handler: "CacheFirst",
       options: {
-        cacheName: 'images',
+        cacheName: "maptiler-tiles",
+        expiration: {
+          maxEntries: 1000,
+          maxAgeSeconds: 60 * 60 * 24 * 30, // 30日
+        },
+      },
+    },
+    {
+      urlPattern: /\.(?:png|jpg|jpeg|svg|gif|webp)$/i,
+      handler: "CacheFirst",
+      options: {
+        cacheName: "images",
         expiration: {
           maxEntries: 100,
           maxAgeSeconds: 60 * 60 * 24 * 30, // 30日
@@ -28,9 +39,9 @@ const withPWA = require('@ducanh2912/next-pwa').default({
     },
     {
       urlPattern: /\.geojson$/i,
-      handler: 'StaleWhileRevalidate',
+      handler: "StaleWhileRevalidate",
       options: {
-        cacheName: 'geojson-data',
+        cacheName: "geojson-data",
         expiration: {
           maxEntries: 10,
           maxAgeSeconds: 60 * 60 * 24 * 7, // 7日
@@ -46,7 +57,7 @@ const nextConfig = {
   reactStrictMode: true,
 
   // 静的エクスポート（Cloudflare Pages用）
-  output: 'export',
+  output: "export",
 
   // 画像最適化（静的エクスポート時は無効）
   images: {
@@ -64,9 +75,9 @@ const nextConfig = {
     // MapLibre GL JSの互換性設定
     resolveAlias: {
       // クライアント側でNode.js組み込みモジュールを無効化
-      fs: './empty.js',
-      net: './empty.js',
-      tls: './empty.js',
+      fs: "./empty.js",
+      net: "./empty.js",
+      tls: "./empty.js",
     },
   },
 
@@ -86,8 +97,8 @@ const nextConfig = {
 
   // 環境変数（クライアント側で使用可能）
   env: {
-    NEXT_PUBLIC_APP_NAME: 'Naruto Shelter Map',
-    NEXT_PUBLIC_APP_VERSION: '0.1.0',
+    NEXT_PUBLIC_APP_NAME: "Naruto Shelter Map",
+    NEXT_PUBLIC_APP_VERSION: "0.1.0",
   },
 };
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from 'next';
 import { Noto_Sans_JP } from 'next/font/google';
 import type { ReactNode } from 'react';
 import { SkipLink } from '@/components/a11y/SkipLink';
+import { InstallPrompt } from '@/components/pwa/InstallPrompt';
+import { OfflineIndicator } from '@/components/pwa/OfflineIndicator';
 import './globals.css';
 
 const notoSansJP = Noto_Sans_JP({
@@ -24,6 +26,8 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       <body className="font-sans antialiased">
         <SkipLink />
         {children}
+        <OfflineIndicator />
+        <InstallPrompt />
       </body>
     </html>
   );

--- a/src/components/pwa/InstallPrompt.tsx
+++ b/src/components/pwa/InstallPrompt.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import type { ReactElement } from 'react';
+import { useState } from 'react';
+import { usePWAInstall } from '@/hooks/usePWAInstall';
+
+/**
+ * PWAインストールプロンプトコンポーネント
+ */
+export function InstallPrompt(): ReactElement | null {
+  const { isInstallable, install } = usePWAInstall();
+  const [isDismissed, setIsDismissed] = useState(false);
+
+  if (!isInstallable || isDismissed) {
+    return null;
+  }
+
+  const handleInstall = async (): Promise<void> => {
+    const success = await install();
+    if (success) {
+      setIsDismissed(true);
+    }
+  };
+
+  const handleDismiss = (): void => {
+    setIsDismissed(true);
+  };
+
+  return (
+    <div
+      className="fixed bottom-4 left-4 right-4 z-50 rounded-lg bg-white p-4 shadow-xl ring-1 ring-black ring-opacity-5 lg:left-auto lg:right-4 lg:w-96"
+      role="alert"
+    >
+      <div className="flex items-start gap-3">
+        <div className="flex-shrink-0">
+          <svg
+            className="h-6 w-6 text-blue-600"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z"
+            />
+          </svg>
+        </div>
+        <div className="flex-1">
+          <h3 className="text-sm font-semibold text-gray-900">
+            アプリをインストール
+          </h3>
+          <p className="mt-1 text-sm text-gray-600">
+            ホーム画面に追加して、オフラインでも避難所情報を確認できます。
+          </p>
+          <div className="mt-3 flex gap-2">
+            <button
+              type="button"
+              onClick={handleInstall}
+              className="rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+            >
+              インストール
+            </button>
+            <button
+              type="button"
+              onClick={handleDismiss}
+              className="rounded-md bg-gray-100 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2"
+            >
+              後で
+            </button>
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={handleDismiss}
+          className="flex-shrink-0 text-gray-400 hover:text-gray-500"
+          aria-label="閉じる"
+        >
+          <svg
+            className="h-5 w-5"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M6 18L18 6M6 6l12 12"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/pwa/OfflineIndicator.tsx
+++ b/src/components/pwa/OfflineIndicator.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import type { ReactElement } from 'react';
+import { useOffline } from '@/hooks/useOffline';
+
+/**
+ * オフライン状態を表示するインジケーター
+ */
+export function OfflineIndicator(): ReactElement | null {
+  const isOffline = useOffline();
+
+  if (!isOffline) {
+    return null;
+  }
+
+  return (
+    <div
+      className="fixed bottom-4 left-1/2 z-50 -translate-x-1/2 rounded-lg bg-gray-900 px-4 py-2 text-sm text-white shadow-lg"
+      role="alert"
+      aria-live="polite"
+    >
+      <div className="flex items-center gap-2">
+        <svg
+          className="h-4 w-4"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M18.364 5.636a9 9 0 010 12.728m0 0l-2.829-2.829m2.829 2.829L21 21M15.536 8.464a5 5 0 010 7.072m0 0l-2.829-2.829m-4.243 2.829a4.978 4.978 0 01-1.414-2.83m-1.414 5.658a9 9 0 01-2.167-9.238m7.824 2.167a1 1 0 111.414 1.414m-1.414-1.414L3 3m8.293 8.293l1.414 1.414"
+          />
+        </svg>
+        <span>オフラインです。キャッシュされたデータを表示しています。</span>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useOffline.ts
+++ b/src/hooks/useOffline.ts
@@ -1,0 +1,34 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+/**
+ * オフライン状態を検出するフック
+ */
+export function useOffline(): boolean {
+  const [isOffline, setIsOffline] = useState(false);
+
+  useEffect(() => {
+    // 初期状態を設定
+    setIsOffline(!navigator.onLine);
+
+    // オンライン/オフラインイベントリスナー
+    const handleOnline = (): void => {
+      setIsOffline(false);
+    };
+
+    const handleOffline = (): void => {
+      setIsOffline(true);
+    };
+
+    window.addEventListener('online', handleOnline);
+    window.addEventListener('offline', handleOffline);
+
+    return () => {
+      window.removeEventListener('online', handleOnline);
+      window.removeEventListener('offline', handleOffline);
+    };
+  }, []);
+
+  return isOffline;
+}

--- a/src/hooks/usePWAInstall.ts
+++ b/src/hooks/usePWAInstall.ts
@@ -1,0 +1,58 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface BeforeInstallPromptEvent extends Event {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>;
+}
+
+/**
+ * PWAインストールプロンプトを管理するフック
+ */
+export function usePWAInstall() {
+  const [deferredPrompt, setDeferredPrompt] =
+    useState<BeforeInstallPromptEvent | null>(null);
+  const [isInstallable, setIsInstallable] = useState(false);
+
+  useEffect(() => {
+    const handler = (e: Event): void => {
+      // デフォルトのプロンプトを防ぐ
+      e.preventDefault();
+      // イベントを保存して後で使用
+      setDeferredPrompt(e as BeforeInstallPromptEvent);
+      setIsInstallable(true);
+    };
+
+    window.addEventListener('beforeinstallprompt', handler);
+
+    return () => {
+      window.removeEventListener('beforeinstallprompt', handler);
+    };
+  }, []);
+
+  const install = async (): Promise<boolean> => {
+    if (!deferredPrompt) {
+      return false;
+    }
+
+    // インストールプロンプトを表示
+    await deferredPrompt.prompt();
+
+    // ユーザーの選択を待つ
+    const { outcome } = await deferredPrompt.userChoice;
+
+    if (outcome === 'accepted') {
+      setDeferredPrompt(null);
+      setIsInstallable(false);
+      return true;
+    }
+
+    return false;
+  };
+
+  return {
+    isInstallable,
+    install,
+  };
+}


### PR DESCRIPTION
## Summary
Phase 6: PWA対応・オフライン強化の実装を開始しました。

## Changes

### Service Worker最適化
- MapTilerタイルのキャッシュ戦略を追加（`next.config.js`）
  - MapTiler APIのリクエストをキャッシュ（30日間、最大1000エントリ）

### オフライン体験向上
- `useOffline`フックを追加（`src/hooks/useOffline.ts`）
  - オンライン/オフライン状態を検出
- `OfflineIndicator`コンポーネントを実装（`src/components/pwa/OfflineIndicator.tsx`）
  - オフライン時に通知を表示

### PWAインストールプロンプト
- `usePWAInstall`フックを追加（`src/hooks/usePWAInstall.ts`）
  - `beforeinstallprompt`イベントを処理
- `InstallPrompt`コンポーネントを実装（`src/components/pwa/InstallPrompt.tsx`）
  - インストール可能時にプロンプトを表示

### その他
- Biomeスキーマバージョンを2.3.4に更新

## Testing
- ✅ TypeScript型チェック通過
- ✅ ビルド成功
- ⏳ PWA Lighthouse監査（次回実施予定）

## Next Steps
- キャッシュ更新通知機能の実装
- PWA Lighthouse監査で100点を達成

🤖 Generated with Claude Code