### PR TITLE
feat(a11y): Add shape-based distinction and tooltip for shelter markers

### DIFF
--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -49,6 +49,21 @@ function getShelterColor(type: string): string {
   }
 }
 
+// 避難所種別に応じたマーカー形状
+// WCAG 1.4.1 Use of Color (Level A) に対応: 色だけでなく形状でも区別可能にする
+function getShelterShape(type: string): string {
+  switch (type) {
+    case '指定避難所':
+      return 'rounded-full'; // 円形
+    case '緊急避難場所':
+      return 'rounded-sm'; // 四角形（角丸）
+    case '両方':
+      return 'rounded-full'; // 円形（星アイコンで区別）
+    default:
+      return 'rounded-full'; // 円形
+  }
+}
+
 // 地図の移動を制御する内部コンポーネント
 function MapController({
   selectedShelterId,
@@ -245,6 +260,7 @@ export function ShelterMap({
         if (!shelter) return null;
 
         const color = getShelterColor(shelter.properties.type);
+        const shape = getShelterShape(shelter.properties.type);
         const isSelected = selectedShelterId === shelter.properties.id;
 
         return (
@@ -257,7 +273,7 @@ export function ShelterMap({
           >
             <button
               type="button"
-              className={`flex cursor-pointer items-center justify-center rounded-full border-2 shadow-lg transition-all hover:scale-110 focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2 ${
+              className={`flex cursor-pointer items-center justify-center border-2 shadow-lg transition-all hover:scale-110 focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2 ${shape} ${
                 isSelected
                   ? 'h-10 w-10 border-blue-500 ring-2 ring-blue-300'
                   : 'h-8 w-8 border-white'
@@ -265,6 +281,7 @@ export function ShelterMap({
               style={{ backgroundColor: color }}
               aria-label={`${shelter.properties.name}（${shelter.properties.type}）`}
               aria-pressed={isSelected}
+              title={`${shelter.properties.name} - ${shelter.properties.type}`}
             >
               {getShelterIcon(shelter.properties.type, {
                 className: 'h-5 w-5 text-white',


### PR DESCRIPTION
## Summary
色だけに依存しない情報表示を実装し、WCAG 1.4.1 Use of Color (Level A) 準拠を改善しました。

## Changes
- \`src/components/map/Map.tsx\`: 
  - マーカーの形状をタイプ別に変更（\`getShelterShape()\`関数を追加）
    - 指定避難所: 円形（\`rounded-full\`）
    - 緊急避難場所: 四角形（\`rounded-sm\`）
    - 両方: 円形（星アイコンで区別）
  - \`title\`属性を追加してホバー時にツールチップで避難所名とタイプを表示

## Problem
現在、避難所タイプは色とアイコンのみで区別されており、色覚多様性のユーザーにとって識別が困難な場合がありました。

## Solution
- **形状による区別**: マーカーの形状をタイプ別に変更することで、色だけでなく形状でも区別可能に
- **ツールチップ**: ホバー時に避難所名とタイプを表示することで、追加の情報提供
- **既存のアイコン**: 既に実装されているアイコン（家、警告、星）と組み合わせて、3つの方法（色・形状・アイコン）で区別可能に

## WCAG 1.4.1 Use of Color (Level A) 対応
- ✅ 色だけでなく形状でも区別可能
- ✅ アイコンでも区別可能（既存実装）
- ✅ ツールチップでテキスト情報も提供

## Test Plan
- [x] Lintチェック通過
- [x] 型チェック通過
- [ ] 地図上でマーカーの形状が正しく表示されることを確認
- [ ] ホバー時にツールチップが表示されることを確認
- [ ] 色覚多様性のユーザーでも区別できることを確認

## Related
- Phase 7: UX/UI改善・アクセシビリティ強化
- WCAG 1.4.1 Use of Color (Level A)

