### PR TITLE
feat(disaster): Phase 8.6.2 - 避難情報の表示機能

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,6 +13,7 @@ import { ShelterDetailModal } from '@/components/shelter/ShelterDetailModal';
 import { ShelterList } from '@/components/shelter/ShelterList';
 import { type SortMode, SortToggle } from '@/components/shelter/SortToggle';
 import { FilterProvider } from '@/contexts/FilterContext';
+import { useEvacuationInfo } from '@/hooks/useEvacuationInfo';
 import { useFavorites } from '@/hooks/useFavorites';
 import { useFilteredShelters } from '@/hooks/useFilteredShelters';
 import { useGeolocation } from '@/hooks/useGeolocation';
@@ -48,6 +49,7 @@ function HomePageContent() {
   } = useGeolocation();
   const { favorites, toggleFavorite } = useFavorites();
   const { data: weatherData } = useWeatherWarnings();
+  const { data: evacuationInfo } = useEvacuationInfo();
   const [sheetState, setSheetState] = useState<SheetState>('minimized');
   const [selectedShelterId, setSelectedShelterId] = useState<string | null>(
     null
@@ -149,6 +151,7 @@ function HomePageContent() {
             geolocationState={geolocationState}
             geolocationError={geolocationError}
             onGetCurrentPosition={getCurrentPosition}
+            evacuationInfo={evacuationInfo ?? []}
           />
 
           {/* Googleマップ風検索バー */}
@@ -251,6 +254,7 @@ function HomePageContent() {
             geolocationState={geolocationState}
             geolocationError={geolocationError}
             onGetCurrentPosition={getCurrentPosition}
+            evacuationInfo={evacuationInfo ?? []}
           />
 
           {/* Googleマップ風検索バー */}

--- a/src/components/disaster/EvacuationLayer.tsx
+++ b/src/components/disaster/EvacuationLayer.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import type { FeatureCollection } from 'geojson';
+import type { Map as MapLibreMap } from 'maplibre-gl';
+import { useEffect } from 'react';
+import { useMap } from 'react-map-gl/maplibre';
+import type { EvacuationInfo } from '@/types/disaster';
+import { EVACUATION_LEVEL_COLORS } from '@/types/disaster';
+
+interface EvacuationLayerProps {
+  evacuationInfo: EvacuationInfo[];
+}
+
+/**
+ * 避難情報を地図上に表示するレイヤーコンポーネント
+ *
+ * MapLibre GL JSのSourceとLayerを使用して、避難情報エリアをポリゴンとして表示します。
+ */
+export function EvacuationLayer({
+  evacuationInfo,
+}: EvacuationLayerProps): null {
+  const mapRef = useMap();
+
+  useEffect(() => {
+    if (!mapRef.current || evacuationInfo.length === 0) return;
+
+    const map = mapRef.current as unknown as MapLibreMap;
+
+    // GeoJSON FeatureCollectionを作成
+    const features = evacuationInfo
+      .filter(
+        (
+          info
+        ): info is EvacuationInfo & {
+          geometry: NonNullable<EvacuationInfo['geometry']>;
+        } => info.geometry !== undefined && info.geometry !== null
+      ) // ジオメトリがあるもののみ
+      .map((info) => ({
+        type: 'Feature' as const,
+        geometry: info.geometry,
+        properties: {
+          level: info.level,
+          name: info.name,
+          description: info.description,
+          areaName: info.areaName,
+        },
+      }));
+
+    if (features.length === 0) return;
+
+    const geojson: FeatureCollection = {
+      type: 'FeatureCollection',
+      features: features as FeatureCollection['features'],
+    };
+
+    // 既存のソースとレイヤーを削除（再描画時）
+    if (map.getSource('evacuation-areas')) {
+      if (map.getLayer('evacuation-fill')) {
+        map.removeLayer('evacuation-fill');
+      }
+      if (map.getLayer('evacuation-outline')) {
+        map.removeLayer('evacuation-outline');
+      }
+      map.removeSource('evacuation-areas');
+    }
+
+    // ソースを追加
+    map.addSource('evacuation-areas', {
+      type: 'geojson',
+      data: geojson,
+    });
+
+    // 塗りつぶしレイヤーを追加
+    map.addLayer({
+      id: 'evacuation-fill',
+      type: 'fill',
+      source: 'evacuation-areas',
+      paint: {
+        'fill-color': [
+          'match',
+          ['get', 'level'],
+          5,
+          EVACUATION_LEVEL_COLORS[5], // レベル5: 黒
+          4,
+          EVACUATION_LEVEL_COLORS[4], // レベル4: 紫
+          3,
+          EVACUATION_LEVEL_COLORS[3], // レベル3: 赤
+          2,
+          EVACUATION_LEVEL_COLORS[2], // レベル2: 青
+          1,
+          EVACUATION_LEVEL_COLORS[1], // レベル1: グレー
+          '#6B7280', // デフォルト: グレー
+        ],
+        'fill-opacity': 0.3,
+      },
+    });
+
+    // アウトライン（輪郭）レイヤーを追加
+    map.addLayer({
+      id: 'evacuation-outline',
+      type: 'line',
+      source: 'evacuation-areas',
+      paint: {
+        'line-color': [
+          'match',
+          ['get', 'level'],
+          5,
+          EVACUATION_LEVEL_COLORS[5],
+          4,
+          EVACUATION_LEVEL_COLORS[4],
+          3,
+          EVACUATION_LEVEL_COLORS[3],
+          2,
+          EVACUATION_LEVEL_COLORS[2],
+          1,
+          EVACUATION_LEVEL_COLORS[1],
+          '#6B7280',
+        ],
+        'line-width': 2,
+        'line-opacity': 0.8,
+      },
+    });
+
+    // クリーンアップ関数
+    return () => {
+      const cleanupMap = (mapRef.current as unknown as MapLibreMap) || null;
+      if (!cleanupMap) return;
+
+      if (cleanupMap.getLayer('evacuation-fill')) {
+        cleanupMap.removeLayer('evacuation-fill');
+      }
+      if (cleanupMap.getLayer('evacuation-outline')) {
+        cleanupMap.removeLayer('evacuation-outline');
+      }
+      if (cleanupMap.getSource('evacuation-areas')) {
+        cleanupMap.removeSource('evacuation-areas');
+      }
+    };
+  }, [mapRef, evacuationInfo]);
+
+  return null;
+}

--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -9,6 +9,7 @@ import MapGL, {
   useMap,
   type ViewStateChangeEvent,
 } from 'react-map-gl/maplibre';
+import { EvacuationLayer } from '@/components/disaster/EvacuationLayer';
 import { useClustering } from '@/hooks/useClustering';
 import type {
   Coordinates,
@@ -18,6 +19,7 @@ import type {
 import { useMapStyle } from '@/hooks/useMapStyle';
 import { generateNavigationURL } from '@/lib/navigation';
 import { getShelterIcon } from '@/lib/shelterIcons';
+import type { EvacuationInfo } from '@/types/disaster';
 import type { ShelterFeature } from '@/types/shelter';
 import { CurrentLocationButton } from './CurrentLocationButton';
 import { MapStyleSwitcher } from './MapStyleSwitcher';
@@ -32,6 +34,7 @@ interface MapProps {
   geolocationState?: GeolocationState;
   geolocationError?: GeolocationError | null;
   onGetCurrentPosition?: () => void;
+  evacuationInfo?: EvacuationInfo[];
 }
 
 // 避難所種別に応じたマーカー色
@@ -102,6 +105,7 @@ export function ShelterMap({
   geolocationState,
   geolocationError,
   onGetCurrentPosition,
+  evacuationInfo = [],
 }: MapProps) {
   const [selectedShelter, setSelectedShelter] = useState<ShelterFeature | null>(
     null
@@ -325,6 +329,11 @@ export function ShelterMap({
           shelters={shelters}
         />
         <NavigationControl position="top-left" />
+
+        {/* 避難情報レイヤー */}
+        {evacuationInfo.length > 0 && (
+          <EvacuationLayer evacuationInfo={evacuationInfo} />
+        )}
 
         {markers}
 

--- a/src/hooks/useEvacuationInfo.ts
+++ b/src/hooks/useEvacuationInfo.ts
@@ -1,0 +1,79 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import type { EvacuationInfo } from '@/types/disaster';
+
+/**
+ * 避難情報を取得するフック
+ *
+ * 注意: 実際のAPIエンドポイントは調査が必要です。
+ * 候補:
+ * - L-Alert（災害情報共有システム）
+ * - 総務省消防庁API
+ * - 鳴門市公式API
+ *
+ * 現時点では、将来の実装のための構造を提供します。
+ */
+export function useEvacuationInfo(): {
+  data: EvacuationInfo[] | null;
+  isLoading: boolean;
+  error: Error | null;
+  retry: () => void;
+} {
+  const [data, setData] = useState<EvacuationInfo[] | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+  const [retryCount, setRetryCount] = useState(0);
+
+  const fetchEvacuationInfo = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      setError(null);
+
+      // TODO: 実際のAPIエンドポイントを実装
+      // 現時点では、モックデータまたは空の配列を返す
+      // 実際のAPIが利用可能になったら、以下のように実装:
+      //
+      // const response = await fetch('https://api.example.com/evacuation-info');
+      // if (!response.ok) {
+      //   throw new Error(`避難情報の取得に失敗しました (HTTP ${response.status})`);
+      // }
+      // const json = await response.json();
+      // setData(json);
+
+      // 現時点では空の配列を返す（避難情報がない状態）
+      setData([]);
+    } catch (err) {
+      const errorMessage =
+        err instanceof Error ? err.message : '避難情報の取得に失敗しました';
+      setError(new Error(errorMessage));
+      setData(null);
+      console.error('Failed to fetch evacuation info:', err);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: retryカウンターによる再フェッチのためretryCountが必要
+  useEffect(() => {
+    fetchEvacuationInfo();
+
+    // 1分ごとに自動更新（緊急時は頻繁に更新）
+    const interval = setInterval(
+      () => {
+        fetchEvacuationInfo();
+      },
+      1 * 60 * 1000
+    );
+
+    return () => {
+      clearInterval(interval);
+    };
+  }, [fetchEvacuationInfo, retryCount]);
+
+  const retry = useCallback((): void => {
+    setRetryCount((prev) => prev + 1);
+  }, []);
+
+  return { data, isLoading, error, retry };
+}


### PR DESCRIPTION
## Summary
地図上に避難情報エリアをポリゴン表示する機能を実装しました。

## Changes
- \`src/hooks/useEvacuationInfo.ts\`: 避難情報を取得するフックを追加
- \`src/components/disaster/EvacuationLayer.tsx\`: 地図上に避難情報エリアを表示するコンポーネントを追加
- \`src/components/map/Map.tsx\`: 避難情報レイヤーを統合
- \`src/app/page.tsx\`: 避難情報フックを統合

## Features
- ✅ 避難情報を取得するフック（将来のAPI実装用の構造）
- ✅ 地図上に避難情報エリアをポリゴン表示
- ✅ 避難レベルに応じた色分け表示（レベル1-5）
- ✅ 1分ごとに自動更新

## Phase 8.6.2 タスク
- [x] 避難情報の取得フック
- [x] 避難情報マッピング（地図上にポリゴン表示）
- [x] 避難レベルに応じた色分け

## 注意事項
- 実際のAPIエンドポイントは調査が必要です
- 現時点では、将来の実装のための構造を提供します
- データソース候補:
  - L-Alert（災害情報共有システム）
  - 総務省消防庁API
  - 鳴門市公式API

## Test Plan
- [ ] 避難情報がある場合に地図上にポリゴンが表示されることを確認
- [ ] 避難レベルに応じた色分けが正しく表示されることを確認
- [ ] 避難情報がない場合にエラーが発生しないことを確認
- [ ] 1分ごとに自動更新されることを確認

## 関連Issue
- #99 feat: Integrate disaster information (weather alerts, river levels, hazard maps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)