### PR TITLE
feat(disaster): Phase 8.6.3 - 河川水位情報の表示機能

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,6 +17,7 @@ import { useEvacuationInfo } from '@/hooks/useEvacuationInfo';
 import { useFavorites } from '@/hooks/useFavorites';
 import { useFilteredShelters } from '@/hooks/useFilteredShelters';
 import { useGeolocation } from '@/hooks/useGeolocation';
+import { useRiverWaterLevels } from '@/hooks/useRiverWaterLevels';
 import { useShelters } from '@/hooks/useShelters';
 import { useWeatherWarnings } from '@/hooks/useWeatherWarnings';
 import { calculateDistance, toCoordinates } from '@/lib/geo';
@@ -50,6 +51,7 @@ function HomePageContent() {
   const { favorites, toggleFavorite } = useFavorites();
   const { data: weatherData } = useWeatherWarnings();
   const { data: evacuationInfo } = useEvacuationInfo();
+  const { data: riverWaterLevels } = useRiverWaterLevels();
   const [sheetState, setSheetState] = useState<SheetState>('minimized');
   const [selectedShelterId, setSelectedShelterId] = useState<string | null>(
     null
@@ -152,6 +154,7 @@ function HomePageContent() {
             geolocationError={geolocationError}
             onGetCurrentPosition={getCurrentPosition}
             evacuationInfo={evacuationInfo ?? []}
+            riverWaterLevels={riverWaterLevels ?? []}
           />
 
           {/* Googleマップ風検索バー */}
@@ -255,6 +258,7 @@ function HomePageContent() {
             geolocationError={geolocationError}
             onGetCurrentPosition={getCurrentPosition}
             evacuationInfo={evacuationInfo ?? []}
+            riverWaterLevels={riverWaterLevels ?? []}
           />
 
           {/* Googleマップ風検索バー */}

--- a/src/components/disaster/RiverWaterLevelLayer.tsx
+++ b/src/components/disaster/RiverWaterLevelLayer.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import type { FeatureCollection } from 'geojson';
+import type { Map as MapLibreMap } from 'maplibre-gl';
+import { useEffect } from 'react';
+import { useMap } from 'react-map-gl/maplibre';
+import type { RiverWaterLevelInfo } from '@/types/disaster';
+import { RIVER_WATER_LEVEL_COLORS } from '@/types/disaster';
+
+interface RiverWaterLevelLayerProps {
+  waterLevels: RiverWaterLevelInfo[];
+}
+
+/**
+ * 河川水位情報を地図上に表示するレイヤーコンポーネント
+ *
+ * MapLibre GL JSのSourceとLayerを使用して、河川ラインと水位レベルを表示します。
+ */
+export function RiverWaterLevelLayer({
+  waterLevels,
+}: RiverWaterLevelLayerProps): null {
+  const mapRef = useMap();
+
+  useEffect(() => {
+    if (!mapRef.current || waterLevels.length === 0) return;
+
+    const map = mapRef.current as unknown as MapLibreMap;
+
+    // GeoJSON FeatureCollectionを作成
+    const features = waterLevels
+      .filter(
+        (
+          info
+        ): info is RiverWaterLevelInfo & {
+          geometry: NonNullable<RiverWaterLevelInfo['geometry']>;
+        } => info.geometry !== undefined && info.geometry !== null
+      ) // ジオメトリがあるもののみ
+      .map((info) => ({
+        type: 'Feature' as const,
+        geometry: info.geometry,
+        properties: {
+          riverName: info.riverName,
+          observationPoint: info.observationPoint,
+          currentLevel: info.currentLevel,
+          warningLevel: info.warningLevel,
+          dangerLevel: info.dangerLevel,
+          level: info.level,
+        },
+      }));
+
+    if (features.length === 0) return;
+
+    const geojson: FeatureCollection = {
+      type: 'FeatureCollection',
+      features: features as FeatureCollection['features'],
+    };
+
+    // 既存のソースとレイヤーを削除（再描画時）
+    if (map.getSource('river-water-levels')) {
+      if (map.getLayer('river-line')) {
+        map.removeLayer('river-line');
+      }
+      if (map.getLayer('river-markers')) {
+        map.removeLayer('river-markers');
+      }
+      map.removeSource('river-water-levels');
+    }
+
+    // ソースを追加
+    map.addSource('river-water-levels', {
+      type: 'geojson',
+      data: geojson,
+    });
+
+    // 河川ラインを追加
+    map.addLayer({
+      id: 'river-line',
+      type: 'line',
+      source: 'river-water-levels',
+      paint: {
+        'line-color': [
+          'match',
+          ['get', 'level'],
+          4,
+          RIVER_WATER_LEVEL_COLORS[4], // レベル4: 赤
+          3,
+          RIVER_WATER_LEVEL_COLORS[3], // レベル3: オレンジ
+          2,
+          RIVER_WATER_LEVEL_COLORS[2], // レベル2: 黄色
+          1,
+          RIVER_WATER_LEVEL_COLORS[1], // レベル1: グレー
+          '#6B7280', // デフォルト: グレー
+        ],
+        'line-width': [
+          'match',
+          ['get', 'level'],
+          4,
+          4, // レベル4: 太め
+          3,
+          3, // レベル3: 中
+          2,
+          2, // レベル2: 細め
+          1,
+          1, // レベル1: 細い
+          1, // デフォルト
+        ],
+        'line-opacity': 0.8,
+      },
+    });
+
+    // クリーンアップ関数
+    return () => {
+      const cleanupMap = (mapRef.current as unknown as MapLibreMap) || null;
+      if (!cleanupMap) return;
+
+      if (cleanupMap.getLayer('river-line')) {
+        cleanupMap.removeLayer('river-line');
+      }
+      if (cleanupMap.getLayer('river-markers')) {
+        cleanupMap.removeLayer('river-markers');
+      }
+      if (cleanupMap.getSource('river-water-levels')) {
+        cleanupMap.removeSource('river-water-levels');
+      }
+    };
+  }, [mapRef, waterLevels]);
+
+  return null;
+}

--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -10,6 +10,7 @@ import MapGL, {
   type ViewStateChangeEvent,
 } from 'react-map-gl/maplibre';
 import { EvacuationLayer } from '@/components/disaster/EvacuationLayer';
+import { RiverWaterLevelLayer } from '@/components/disaster/RiverWaterLevelLayer';
 import { useClustering } from '@/hooks/useClustering';
 import type {
   Coordinates,
@@ -19,7 +20,7 @@ import type {
 import { useMapStyle } from '@/hooks/useMapStyle';
 import { generateNavigationURL } from '@/lib/navigation';
 import { getShelterIcon } from '@/lib/shelterIcons';
-import type { EvacuationInfo } from '@/types/disaster';
+import type { EvacuationInfo, RiverWaterLevelInfo } from '@/types/disaster';
 import type { ShelterFeature } from '@/types/shelter';
 import { CurrentLocationButton } from './CurrentLocationButton';
 import { MapStyleSwitcher } from './MapStyleSwitcher';
@@ -35,6 +36,7 @@ interface MapProps {
   geolocationError?: GeolocationError | null;
   onGetCurrentPosition?: () => void;
   evacuationInfo?: EvacuationInfo[];
+  riverWaterLevels?: RiverWaterLevelInfo[];
 }
 
 // 避難所種別に応じたマーカー色
@@ -106,6 +108,7 @@ export function ShelterMap({
   geolocationError,
   onGetCurrentPosition,
   evacuationInfo = [],
+  riverWaterLevels = [],
 }: MapProps) {
   const [selectedShelter, setSelectedShelter] = useState<ShelterFeature | null>(
     null
@@ -333,6 +336,11 @@ export function ShelterMap({
         {/* 避難情報レイヤー */}
         {evacuationInfo.length > 0 && (
           <EvacuationLayer evacuationInfo={evacuationInfo} />
+        )}
+
+        {/* 河川水位情報レイヤー */}
+        {riverWaterLevels.length > 0 && (
+          <RiverWaterLevelLayer waterLevels={riverWaterLevels} />
         )}
 
         {markers}

--- a/src/hooks/useRiverWaterLevels.ts
+++ b/src/hooks/useRiverWaterLevels.ts
@@ -1,0 +1,92 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import type { RiverWaterLevelInfo } from '@/types/disaster';
+
+/**
+ * 河川水位情報を取得するフック
+ *
+ * 国土交通省の川の防災情報APIから鳴門市周辺の河川（旧吉野川、今切川）の水位情報を取得します。
+ * API: https://www.river.go.jp/
+ *
+ * 注意: 実際のAPIエンドポイントは調査が必要です。
+ * 現時点では、将来の実装のための構造を提供します。
+ */
+export function useRiverWaterLevels(): {
+  data: RiverWaterLevelInfo[] | null;
+  isLoading: boolean;
+  error: Error | null;
+  retry: () => void;
+} {
+  const [data, setData] = useState<RiverWaterLevelInfo[] | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+  const [retryCount, setRetryCount] = useState(0);
+
+  // 鳴門市周辺の河川観測所
+  // TODO: 実際の観測所コードを調査
+  // const OBSERVATION_POINTS = [
+  //   {
+  //     riverName: '旧吉野川',
+  //     observationPoint: '鳴門観測所',
+  //     coordinates: [134.6, 34.17] as [number, number],
+  //   },
+  //   {
+  //     riverName: '今切川',
+  //     observationPoint: '鳴門観測所',
+  //     coordinates: [134.6, 34.18] as [number, number],
+  //   },
+  // ];
+
+  const fetchRiverWaterLevels = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      setError(null);
+
+      // TODO: 実際のAPIエンドポイントを実装
+      // 現時点では、モックデータまたは空の配列を返す
+      // 実際のAPIが利用可能になったら、以下のように実装:
+      //
+      // const response = await fetch('https://api.river.go.jp/water-levels');
+      // if (!response.ok) {
+      //   throw new Error(`河川水位情報の取得に失敗しました (HTTP ${response.status})`);
+      // }
+      // const json = await response.json();
+      // setData(json);
+
+      // 現時点では空の配列を返す（水位情報がない状態）
+      setData([]);
+    } catch (err) {
+      const errorMessage =
+        err instanceof Error ? err.message : '河川水位情報の取得に失敗しました';
+      setError(new Error(errorMessage));
+      setData(null);
+      console.error('Failed to fetch river water levels:', err);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: retryカウンターによる再フェッチのためretryCountが必要
+  useEffect(() => {
+    fetchRiverWaterLevels();
+
+    // 10分ごとに自動更新
+    const interval = setInterval(
+      () => {
+        fetchRiverWaterLevels();
+      },
+      10 * 60 * 1000
+    );
+
+    return () => {
+      clearInterval(interval);
+    };
+  }, [fetchRiverWaterLevels, retryCount]);
+
+  const retry = useCallback((): void => {
+    setRetryCount((prev) => prev + 1);
+  }, []);
+
+  return { data, isLoading, error, retry };
+}

--- a/src/types/disaster.ts
+++ b/src/types/disaster.ts
@@ -95,3 +95,46 @@ export const EVACUATION_LEVEL_DESCRIPTIONS: Record<EvacuationLevel, string> = {
   4: '避難指示',
   5: '緊急安全確保',
 };
+
+/**
+ * 河川水位レベル
+ */
+export type RiverWaterLevel = 1 | 2 | 3 | 4;
+
+/**
+ * 河川水位情報
+ */
+export interface RiverWaterLevelInfo {
+  riverName: string;
+  observationPoint: string;
+  currentLevel: number; // 現在の水位（m）
+  warningLevel: number; // 氾濫注意水位（m）
+  dangerLevel: number; // 氾濫危険水位（m）
+  level: RiverWaterLevel; // 水位レベル（1-4）
+  updatedAt: string;
+  coordinates?: [number, number]; // [経度, 緯度]
+  geometry?: {
+    type: 'LineString' | 'MultiLineString';
+    coordinates: number[][] | number[][][];
+  };
+}
+
+/**
+ * 河川水位レベルと色のマッピング
+ */
+export const RIVER_WATER_LEVEL_COLORS: Record<RiverWaterLevel, string> = {
+  1: '#6B7280', // グレー: 通常（水防団待機水位）
+  2: '#FCD34D', // 黄色: 氾濫注意水位
+  3: '#FB923C', // オレンジ: 避難判断水位
+  4: '#EF4444', // 赤: 氾濫危険水位
+};
+
+/**
+ * 河川水位レベルの説明
+ */
+export const RIVER_WATER_LEVEL_DESCRIPTIONS: Record<RiverWaterLevel, string> = {
+  1: '通常（水防団待機水位）',
+  2: '氾濫注意水位',
+  3: '避難判断水位',
+  4: '氾濫危険水位',
+};


### PR DESCRIPTION
## Summary
地図上に河川水位情報を表示する機能を実装しました。

## Changes
- \`src/types/disaster.ts\`: 河川水位情報の型定義を追加
- \`src/hooks/useRiverWaterLevels.ts\`: 河川水位情報を取得するフックを追加
- \`src/components/disaster/RiverWaterLevelLayer.tsx\`: 地図上に河川ラインを表示するコンポーネントを追加
- \`src/components/map/Map.tsx\`: 河川水位情報レイヤーを統合
- \`src/app/page.tsx\`: 河川水位情報フックを統合

## Features
- ✅ 河川水位情報を取得するフック（将来のAPI実装用の構造）
- ✅ 地図上に河川ラインを表示
- ✅ 水位レベルに応じた色分け表示（レベル1-4）
- ✅ 10分ごとに自動更新

## Phase 8.6.3 タスク
- [x] 河川水位情報の型定義
- [x] 河川水位情報取得フック
- [x] 河川ライン表示レイヤー
- [x] 水位レベルに応じた色分け

## 注意事項
- 実際のAPIエンドポイントは調査が必要です
- 現時点では、将来の実装のための構造を提供します
- データソース候補:
  - 国土交通省 川の防災情報API
  - https://www.river.go.jp/

## Test Plan
- [ ] 河川水位情報がある場合に地図上にラインが表示されることを確認
- [ ] 水位レベルに応じた色分けが正しく表示されることを確認
- [ ] 河川水位情報がない場合にエラーが発生しないことを確認
- [ ] 10分ごとに自動更新されることを確認

## 関連Issue
- #99 feat: Integrate disaster information (weather alerts, river levels, hazard maps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)