### PR TITLE
feat(disaster): ハザードマップオーバーレイ機能を追加

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,6 +16,7 @@ import { useEvacuationInfo } from '@/hooks/useEvacuationInfo';
 import { useFavorites } from '@/hooks/useFavorites';
 import { useFilteredShelters } from '@/hooks/useFilteredShelters';
 import { useGeolocation } from '@/hooks/useGeolocation';
+import { useHazardMaps } from '@/hooks/useHazardMaps';
 import { useRiverWaterLevels } from '@/hooks/useRiverWaterLevels';
 import { useShelters } from '@/hooks/useShelters';
 import { useWeatherWarnings } from '@/hooks/useWeatherWarnings';
@@ -51,6 +52,7 @@ function HomePageContent() {
   const { data: weatherData } = useWeatherWarnings();
   const { data: evacuationInfo } = useEvacuationInfo();
   const { data: riverWaterLevels } = useRiverWaterLevels();
+  const { data: hazardMaps } = useHazardMaps();
   const [sheetState, setSheetState] = useState<SheetState>('minimized');
   const [selectedShelterId, setSelectedShelterId] = useState<string | null>(
     null
@@ -139,6 +141,7 @@ function HomePageContent() {
             onGetCurrentPosition={getCurrentPosition}
             evacuationInfo={evacuationInfo ?? []}
             riverWaterLevels={riverWaterLevels ?? []}
+            hazardMaps={hazardMaps ?? []}
           />
         </main>
 
@@ -235,6 +238,7 @@ function HomePageContent() {
             onGetCurrentPosition={getCurrentPosition}
             evacuationInfo={evacuationInfo ?? []}
             riverWaterLevels={riverWaterLevels ?? []}
+            hazardMaps={hazardMaps ?? []}
           />
         </main>
       </div>

--- a/src/components/disaster/HazardMapLayer.tsx
+++ b/src/components/disaster/HazardMapLayer.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import type { FeatureCollection } from 'geojson';
+import type { Map as MapLibreMap } from 'maplibre-gl';
+import { useEffect } from 'react';
+import { useMap } from 'react-map-gl/maplibre';
+import type { HazardMapInfo } from '@/types/disaster';
+import { HAZARD_MAP_COLORS } from '@/types/disaster';
+
+interface HazardMapLayerProps {
+  hazardMaps: HazardMapInfo[];
+  enabled?: boolean;
+}
+
+/**
+ * ハザードマップを地図上に表示するレイヤーコンポーネント
+ *
+ * MapLibre GL JSのSourceとLayerを使用して、ハザードマップエリアをポリゴンとして表示します。
+ * 各ハザードマップ種別（洪水、土砂災害、津波、地震）ごとに異なる色で表示します。
+ */
+export function HazardMapLayer({
+  hazardMaps,
+  enabled = true,
+}: HazardMapLayerProps): null {
+  const mapRef = useMap();
+
+  useEffect(() => {
+    if (!mapRef.current || !enabled || hazardMaps.length === 0) return;
+
+    const map = mapRef.current as unknown as MapLibreMap;
+
+    // GeoJSON FeatureCollectionを作成
+    const features = hazardMaps
+      .filter(
+        (
+          info
+        ): info is HazardMapInfo & {
+          geometry: NonNullable<HazardMapInfo['geometry']>;
+        } => info.geometry !== undefined && info.geometry !== null
+      ) // ジオメトリがあるもののみ
+      .map((info) => ({
+        type: 'Feature' as const,
+        geometry: info.geometry,
+        properties: {
+          type: info.type,
+          name: info.name,
+          description: info.description,
+          areaName: info.areaName,
+        },
+      }));
+
+    if (features.length === 0) return;
+
+    const geojson: FeatureCollection = {
+      type: 'FeatureCollection',
+      features: features as FeatureCollection['features'],
+    };
+
+    // 既存のソースとレイヤーを削除（再描画時）
+    if (map.getSource('hazard-maps')) {
+      if (map.getLayer('hazard-map-fill')) {
+        map.removeLayer('hazard-map-fill');
+      }
+      if (map.getLayer('hazard-map-outline')) {
+        map.removeLayer('hazard-map-outline');
+      }
+      map.removeSource('hazard-maps');
+    }
+
+    // ソースを追加
+    map.addSource('hazard-maps', {
+      type: 'geojson',
+      data: geojson,
+    });
+
+    // 塗りつぶしレイヤーを追加
+    map.addLayer({
+      id: 'hazard-map-fill',
+      type: 'fill',
+      source: 'hazard-maps',
+      paint: {
+        'fill-color': [
+          'match',
+          ['get', 'type'],
+          'flood',
+          HAZARD_MAP_COLORS.flood, // 青: 洪水
+          'sediment',
+          HAZARD_MAP_COLORS.sediment, // オレンジ: 土砂災害
+          'tsunami',
+          HAZARD_MAP_COLORS.tsunami, // 緑: 津波
+          'earthquake',
+          HAZARD_MAP_COLORS.earthquake, // 赤: 地震
+          '#6B7280', // デフォルト: グレー
+        ],
+        'fill-opacity': 0.2, // 半透明で表示（他の情報と重ならないように）
+      },
+    });
+
+    // アウトライン（輪郭）レイヤーを追加
+    map.addLayer({
+      id: 'hazard-map-outline',
+      type: 'line',
+      source: 'hazard-maps',
+      paint: {
+        'line-color': [
+          'match',
+          ['get', 'type'],
+          'flood',
+          HAZARD_MAP_COLORS.flood,
+          'sediment',
+          HAZARD_MAP_COLORS.sediment,
+          'tsunami',
+          HAZARD_MAP_COLORS.tsunami,
+          'earthquake',
+          HAZARD_MAP_COLORS.earthquake,
+          '#6B7280',
+        ],
+        'line-width': 2,
+        'line-opacity': 0.6,
+      },
+    });
+
+    // クリーンアップ関数
+    return () => {
+      const cleanupMap = (mapRef.current as unknown as MapLibreMap) || null;
+      if (!cleanupMap) return;
+
+      if (cleanupMap.getLayer('hazard-map-fill')) {
+        cleanupMap.removeLayer('hazard-map-fill');
+      }
+      if (cleanupMap.getLayer('hazard-map-outline')) {
+        cleanupMap.removeLayer('hazard-map-outline');
+      }
+      if (cleanupMap.getSource('hazard-maps')) {
+        cleanupMap.removeSource('hazard-maps');
+      }
+    };
+  }, [mapRef, hazardMaps, enabled]);
+
+  return null;
+}

--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -10,6 +10,7 @@ import MapGL, {
   type ViewStateChangeEvent,
 } from 'react-map-gl/maplibre';
 import { EvacuationLayer } from '@/components/disaster/EvacuationLayer';
+import { HazardMapLayer } from '@/components/disaster/HazardMapLayer';
 import { RiverWaterLevelLayer } from '@/components/disaster/RiverWaterLevelLayer';
 import { useClustering } from '@/hooks/useClustering';
 import type {
@@ -19,7 +20,11 @@ import type {
 } from '@/hooks/useGeolocation';
 import { generateNavigationURL } from '@/lib/navigation';
 import { getShelterIcon } from '@/lib/shelterIcons';
-import type { EvacuationInfo, RiverWaterLevelInfo } from '@/types/disaster';
+import type {
+  EvacuationInfo,
+  HazardMapInfo,
+  RiverWaterLevelInfo,
+} from '@/types/disaster';
 import { MAP_STYLES } from '@/types/map';
 import type { ShelterFeature } from '@/types/shelter';
 import { CurrentLocationButton } from './CurrentLocationButton';
@@ -36,6 +41,7 @@ interface MapProps {
   onGetCurrentPosition?: () => void;
   evacuationInfo?: EvacuationInfo[];
   riverWaterLevels?: RiverWaterLevelInfo[];
+  hazardMaps?: HazardMapInfo[];
 }
 
 // 避難所種別に応じたマーカー色
@@ -108,6 +114,7 @@ export function ShelterMap({
   onGetCurrentPosition,
   evacuationInfo = [],
   riverWaterLevels = [],
+  hazardMaps = [],
 }: MapProps) {
   const [selectedShelter, setSelectedShelter] = useState<ShelterFeature | null>(
     null
@@ -340,6 +347,11 @@ export function ShelterMap({
         {/* 河川水位情報レイヤー */}
         {riverWaterLevels.length > 0 && (
           <RiverWaterLevelLayer waterLevels={riverWaterLevels} />
+        )}
+
+        {/* ハザードマップレイヤー */}
+        {hazardMaps.length > 0 && (
+          <HazardMapLayer hazardMaps={hazardMaps} enabled />
         )}
 
         {markers}

--- a/src/hooks/useHazardMaps.ts
+++ b/src/hooks/useHazardMaps.ts
@@ -1,0 +1,77 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import type { HazardMapInfo } from '@/types/disaster';
+
+/**
+ * ハザードマップ情報を取得するカスタムフック
+ *
+ * 現在はプレースホルダー実装。
+ * 将来的には国土地理院のハザードマップAPIや
+ * 鳴門市のハザードマップデータと連携する予定。
+ */
+export function useHazardMaps(): {
+  data: HazardMapInfo[] | null;
+  isLoading: boolean;
+  error: Error | null;
+  retry: () => void;
+} {
+  const [data, setData] = useState<HazardMapInfo[] | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+  const [retryCount, setRetryCount] = useState(0);
+
+  const fetchHazardMaps = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      setError(null);
+
+      // TODO: 実際のAPIエンドポイントを実装
+      // 現時点では、モックデータまたは空の配列を返す
+      // 実際のAPIが利用可能になったら、以下のように実装:
+      //
+      // const response = await fetch('https://api.example.com/hazard-maps');
+      // if (!response.ok) {
+      //   throw new Error(`ハザードマップ情報の取得に失敗しました (HTTP ${response.status})`);
+      // }
+      // const json = await response.json();
+      // setData(json);
+
+      // 現時点では空の配列を返す（ハザードマップ情報がない状態）
+      setData([]);
+    } catch (err) {
+      const errorMessage =
+        err instanceof Error
+          ? err.message
+          : 'ハザードマップ情報の取得に失敗しました';
+      setError(new Error(errorMessage));
+      setData(null);
+      console.error('Failed to fetch hazard maps:', err);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: retryカウンターによる再フェッチのためretryCountが必要
+  useEffect(() => {
+    fetchHazardMaps();
+
+    // 10分ごとに自動更新
+    const interval = setInterval(
+      () => {
+        fetchHazardMaps();
+      },
+      10 * 60 * 1000
+    );
+
+    return () => {
+      clearInterval(interval);
+    };
+  }, [fetchHazardMaps, retryCount]);
+
+  const retry = useCallback((): void => {
+    setRetryCount((prev) => prev + 1);
+  }, []);
+
+  return { data, isLoading, error, retry };
+}

--- a/src/types/disaster.ts
+++ b/src/types/disaster.ts
@@ -138,3 +138,44 @@ export const RIVER_WATER_LEVEL_DESCRIPTIONS: Record<RiverWaterLevel, string> = {
   3: '避難判断水位',
   4: '氾濫危険水位',
 };
+
+/**
+ * ハザードマップの種類
+ */
+export type HazardMapType = 'flood' | 'sediment' | 'tsunami' | 'earthquake';
+
+/**
+ * ハザードマップ情報
+ */
+export interface HazardMapInfo {
+  type: HazardMapType;
+  name: string;
+  description: string;
+  areaCode: string;
+  areaName: string;
+  updatedAt: string;
+  geometry?: {
+    type: 'Polygon' | 'MultiPolygon';
+    coordinates: number[][][] | number[][][][];
+  };
+}
+
+/**
+ * ハザードマップ種別と色のマッピング
+ */
+export const HAZARD_MAP_COLORS: Record<HazardMapType, string> = {
+  flood: '#3B82F6', // 青: 洪水
+  sediment: '#F59E0B', // オレンジ: 土砂災害
+  tsunami: '#10B981', // 緑: 津波
+  earthquake: '#EF4444', // 赤: 地震
+};
+
+/**
+ * ハザードマップ種別の説明
+ */
+export const HAZARD_MAP_DESCRIPTIONS: Record<HazardMapType, string> = {
+  flood: '洪水ハザードマップ',
+  sediment: '土砂災害ハザードマップ',
+  tsunami: '津波ハザードマップ',
+  earthquake: '地震ハザードマップ',
+};


### PR DESCRIPTION
## Summary
ハザードマップオーバーレイ機能を追加しました。洪水、土砂災害、津波、地震のハザードマップを地図上に表示できるようになりました。

## Changes
- \`src/types/disaster.ts\`: ハザードマップの型定義を追加
- \`src/hooks/useHazardMaps.ts\`: ハザードマップデータ取得フックを作成
- \`src/components/disaster/HazardMapLayer.tsx\`: ハザードマップレイヤーコンポーネントを作成
- \`src/components/map/Map.tsx\`: ハザードマップレイヤーを統合
- \`src/app/page.tsx\`: メインページにハザードマップ機能を統合

## Phase 8.6.4 対応
- ハザードマップオーバーレイ機能を実装
- 災害情報統合の最後のピースを完成

## ハザードマップ種別
- 洪水: 青（#3B82F6）
- 土砂災害: オレンジ（#F59E0B）
- 津波: 緑（#10B981）
- 地震: 赤（#EF4444）

## UI/UX
- 半透明（opacity: 0.2）で表示し、他の情報と重ならないように調整
- アウトライン（opacity: 0.6）で境界を明確に表示
- 各ハザードマップ種別ごとに異なる色で識別可能

## 注意
現在はプレースホルダー実装です。将来的には国土地理院のハザードマップAPIや
鳴門市のハザードマップデータと連携する予定です。

## Test Plan
- [ ] ハザードマップレイヤーが正しく表示されることを確認
- [ ] 各ハザードマップ種別の色が正しく表示されることを確認
- [ ] 半透明表示が正常に動作することを確認
- [ ] 他のレイヤー（避難情報、河川水位）と重なっても問題なく表示されることを確認
- [ ] ハザードマップデータがない場合でもエラーが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)