### PR TITLE
docs: Phase 10（CI/CD強化）を削除

### DIFF
--- a/.docs/PRODUCT-ROADMAP.md
+++ b/.docs/PRODUCT-ROADMAP.md
@@ -49,7 +49,7 @@
 
 ### 進行中（🚧 In Progress）
 
-- [ ] **Phase 10:** CI/CD 強化
+なし
 
 ---
 
@@ -72,10 +72,10 @@
 ## 🗺️ ロードマップ概要
 
 ```
-Phase 6      Phase 7    Phase 8    Phase 10
-PWA対応      UX改善     多機能化   CI/CD強化
+Phase 6      Phase 7    Phase 8
+PWA対応      UX改善     多機能化
 
-[基盤強化] → [体験向上] → [機能拡張] → [品質向上]
+[基盤強化] → [体験向上] → [機能拡張]
 ```
 
 ---
@@ -256,38 +256,6 @@ PWA対応      UX改善     多機能化   CI/CD強化
 
 ---
 
-## Phase 10: CI/CD 強化 ⭐️⭐️⭐️⭐️⭐️
-
-**ゴール:** 自動テストとパフォーマンス監視の実装
-**優先度:** 🔵 LOW（長期的）
-
-### 目標
-
-- コード品質の向上
-- 自動化による開発効率向上
-
-### タスク
-
-#### 10.1 CI/CD 強化
-
-- [ ] 自動テスト（Unit, Integration, E2E）
-- [ ] Visual Regression Testing
-- [ ] パフォーマンス監視（Lighthouse CI）
-- [ ] セキュリティスキャン（Dependabot, Snyk）
-
-### 成果物
-
-- 自動テストスイート
-- CI/CD パイプライン
-- パフォーマンス監視システム
-
-### 成功指標（KPI）
-
-- ✅ テストカバレッジ: **80%以上**
-- ✅ CI/CD パイプライン成功率: **95%以上**
-
----
-
 ## 🎨 Future Ideas（アイデア集）
 
 ### アイデアバックログ
@@ -342,7 +310,6 @@ PWA対応      UX改善     多機能化   CI/CD強化
 | Lighthouse Accessibility | 100    | -      | ✅ Phase 7  |
 | Core Web Vitals (Good)   | 100%   | -      | ✅ Phase 7  |
 | TypeScript Errors        | 0      | 0      | ✅          |
-| Test Coverage            | 80%+   | -      | 🚧 Phase 10 |
 
 ### プロダクト指標
 


### PR DESCRIPTION
## Summary
Phase 10（CI/CD強化）が不要と判断したため、削除しました。

## Changes
- `.docs/PRODUCT-ROADMAP.md`:
  - Phase 10のセクション全体を削除
  - 進行中セクションを「なし」に更新
  - ロードマップ概要からPhase 10を削除
  - 成功指標からTest Coverageを削除

## Related Issues
- Related to #76 (Phase 10: エコシステム化・持続可能性)

🤖 Generated with [Claude Code](https://claude.com/claude-code)