### PR TITLE
docs: 災害情報APIのTODOコメントを更新し、利用可能なAPI情報を追加

### DIFF
--- a/src/hooks/useEvacuationInfo.ts
+++ b/src/hooks/useEvacuationInfo.ts
@@ -6,12 +6,20 @@ import type { EvacuationInfo } from '@/types/disaster';
 /**
  * 避難情報を取得するフック
  *
- * 注意: 実際のAPIエンドポイントは調査が必要です。
- * 候補:
- * - L-Alert（災害情報共有システム）
- * - 総務省消防庁API
- * - 鳴門市公式API
+ * 以下のAPIが利用可能（実装時は詳細を確認すること）:
  *
+ * - DMDATA.JP Service
+ *   - 気象庁が配信する地震情報、津波情報、気象警報などをWebSocketでリアルタイム配信
+ *   - https://dmdata.jp/
+ *
+ * - 全国避難所ガイド「開設避難所・混雑状況API」
+ *   - 開設されている避難所の位置情報と混雑状況を提供
+ *   - https://www.hinanjyo.jp/api.html
+ *
+ * - L-Alert（災害情報共有システム）
+ *   - APIの公開状況は要確認
+ *
+ * 実装時は、エンドポイントURL、認証方法、データ形式を確認してから実装すること。
  * 現時点では、将来の実装のための構造を提供します。
  */
 export function useEvacuationInfo(): {
@@ -31,15 +39,12 @@ export function useEvacuationInfo(): {
       setError(null);
 
       // TODO: 実際のAPIエンドポイントを実装
+      // 利用可能なAPI:
+      // - DMDATA.JP Service (WebSocket)
+      // - 全国避難所ガイド「開設避難所・混雑状況API」
+      // - L-Alert（要確認）
+      // 実装時は、エンドポイントURL、認証方法、データ形式を確認してから実装すること。
       // 現時点では、モックデータまたは空の配列を返す
-      // 実際のAPIが利用可能になったら、以下のように実装:
-      //
-      // const response = await fetch('https://api.example.com/evacuation-info');
-      // if (!response.ok) {
-      //   throw new Error(`避難情報の取得に失敗しました (HTTP ${response.status})`);
-      // }
-      // const json = await response.json();
-      // setData(json);
 
       // 現時点では空の配列を返す（避難情報がない状態）
       setData([]);

--- a/src/hooks/useHazardMaps.ts
+++ b/src/hooks/useHazardMaps.ts
@@ -7,8 +7,17 @@ import type { HazardMapInfo } from '@/types/disaster';
  * ハザードマップ情報を取得するカスタムフック
  *
  * 現在はプレースホルダー実装。
- * 将来的には国土地理院のハザードマップAPIや
- * 鳴門市のハザードマップデータと連携する予定。
+ * 将来的には以下のAPIと連携する予定：
+ *
+ * - 国土交通省「不動産情報ライブラリ」防災情報API
+ *   - 洪水浸水想定区域、土砂災害警戒区域、津波浸水想定、高潮浸水想定区域を提供
+ *   - https://www.mlit.go.jp/report/press/tochi_fudousan_kensetsugyo17_hh_000001_00068.html
+ *
+ * - 全国避難所ガイド「全国ハザードデータベースAPI」
+ *   - 土砂災害警戒区域、洪水浸水想定区域、津波浸水想定区域のデータを提供
+ *   - https://www.hinanjyo.jp/api.html
+ *
+ * 実装時は、エンドポイントURL、認証方法、データ形式を確認してから実装すること。
  */
 export function useHazardMaps(): {
   data: HazardMapInfo[] | null;
@@ -27,15 +36,11 @@ export function useHazardMaps(): {
       setError(null);
 
       // TODO: 実際のAPIエンドポイントを実装
+      // 利用可能なAPI:
+      // - 国土交通省「不動産情報ライブラリ」防災情報API
+      // - 全国避難所ガイド「全国ハザードデータベースAPI」
+      // 実装時は、エンドポイントURL、認証方法、データ形式を確認してから実装すること。
       // 現時点では、モックデータまたは空の配列を返す
-      // 実際のAPIが利用可能になったら、以下のように実装:
-      //
-      // const response = await fetch('https://api.example.com/hazard-maps');
-      // if (!response.ok) {
-      //   throw new Error(`ハザードマップ情報の取得に失敗しました (HTTP ${response.status})`);
-      // }
-      // const json = await response.json();
-      // setData(json);
 
       // 現時点では空の配列を返す（ハザードマップ情報がない状態）
       setData([]);

--- a/src/hooks/useRiverWaterLevels.ts
+++ b/src/hooks/useRiverWaterLevels.ts
@@ -6,10 +6,14 @@ import type { RiverWaterLevelInfo } from '@/types/disaster';
 /**
  * 河川水位情報を取得するフック
  *
- * 国土交通省の川の防災情報APIから鳴門市周辺の河川（旧吉野川、今切川）の水位情報を取得します。
- * API: https://www.river.go.jp/
+ * 国土交通省の川の防災情報から鳴門市周辺の河川（旧吉野川、今切川）の水位情報を取得します。
+ * データは公開されているが、REST APIの詳細なエンドポイントは要確認。
  *
- * 注意: 実際のAPIエンドポイントは調査が必要です。
+ * 参考:
+ * - 国土交通省「川の防災情報」: https://www.river.go.jp/
+ * - 各河川管理事務所が個別にAPIを提供している場合あり
+ *
+ * 実装時は、エンドポイントURL、認証方法、データ形式を確認してから実装すること。
  * 現時点では、将来の実装のための構造を提供します。
  */
 export function useRiverWaterLevels(): {
@@ -25,6 +29,7 @@ export function useRiverWaterLevels(): {
 
   // 鳴門市周辺の河川観測所
   // TODO: 実際の観測所コードを調査
+  // 国土交通省「川の防災情報」から観測所情報を取得する必要がある
   // const OBSERVATION_POINTS = [
   //   {
   //     riverName: '旧吉野川',
@@ -44,15 +49,9 @@ export function useRiverWaterLevels(): {
       setError(null);
 
       // TODO: 実際のAPIエンドポイントを実装
+      // 国土交通省「川の防災情報」のREST APIエンドポイントを調査して実装すること。
+      // 実装時は、エンドポイントURL、認証方法、データ形式を確認してから実装すること。
       // 現時点では、モックデータまたは空の配列を返す
-      // 実際のAPIが利用可能になったら、以下のように実装:
-      //
-      // const response = await fetch('https://api.river.go.jp/water-levels');
-      // if (!response.ok) {
-      //   throw new Error(`河川水位情報の取得に失敗しました (HTTP ${response.status})`);
-      // }
-      // const json = await response.json();
-      // setData(json);
 
       // 現時点では空の配列を返す（水位情報がない状態）
       setData([]);


### PR DESCRIPTION
## Summary
災害情報APIのTODOコメントを更新し、調査結果として利用可能なAPIの情報を追加しました。実装は将来の課題としてIssueに記録しました。

## Changes
- `src/hooks/useHazardMaps.ts`: 国土交通省「不動産情報ライブラリ」と全国避難所ガイドのAPI情報を追加
- `src/hooks/useRiverWaterLevels.ts`: 国土交通省「川の防災情報」の情報を追加
- `src/hooks/useEvacuationInfo.ts`: DMDATA.JP Serviceと全国避難所ガイドのAPI情報を追加
- 各TODOコメントに実装時の注意事項（エンドポイントURL、認証方法、データ形式の確認）を追加

## Related Issues
- #171: feat: ハザードマップ情報APIの実装
- #172: feat: 河川水位情報APIの実装
- #173: feat: 避難情報APIの実装

🤖 Generated with [Claude Code](https://claude.com/claude-code)