### PR TITLE
fix: スマホで拡大縮小アイコンを表示し、現在地ボタンの位置を調整

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -59,9 +59,4 @@
   padding: 8px;
 }
 
-/* モバイルでナビゲーションコントロールを非表示 */
-@media (max-width: 1023px) {
-  .maplibregl-ctrl-top-right {
-    display: none !important;
-  }
-}
+/* モバイルでもナビゲーションコントロールを表示（右上に配置） */

--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -385,7 +385,7 @@ export function ShelterMap({
       </MapGL>
 
       {/* 現在地ボタン - モバイル: 右下（タブバーの上 = 80px + マージン）、PC: 右下 */}
-      <div className="absolute bottom-28 right-4 z-10 lg:bottom-20 lg:right-4">
+      <div className="absolute bottom-32 right-4 z-10 lg:bottom-20 lg:right-4">
         <CurrentLocationButton
           onClick={handleLocationButtonClick}
           state={state}


### PR DESCRIPTION
## Summary
スマホレイアウトで拡大縮小アイコンが消えていた問題と、現在地ボタンがfooterと重なる問題を修正しました。

## Changes
- `src/app/globals.css`:
  - モバイルでNavigationControlを非表示にしていたCSSを削除
  - 拡大縮小アイコンがスマホでも表示されるように修正

- `src/components/map/Map.tsx`:
  - 現在地ボタンのbottom位置を`bottom-28`（112px）から`bottom-32`（128px）に変更
  - ViewModeTabsの実際の高さを考慮してマージンを確保

## Fixes
- Fixes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)