### PR TITLE
chore: Update README version badges and remove console.log in production

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 [![Deploy to Cloudflare Pages](https://img.shields.io/badge/deploy-cloudflare-orange)](https://pages.cloudflare.com)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![pnpm](https://img.shields.io/badge/pnpm-9.x-orange)](https://pnpm.io/)
-[![Next.js](https://img.shields.io/badge/Next.js-15-black)](https://nextjs.org/)
+[![Next.js](https://img.shields.io/badge/Next.js-16-black)](https://nextjs.org/)
 [![React](https://img.shields.io/badge/React-19-blue)](https://react.dev/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.x-blue)](https://www.typescriptlang.org/)
 [![Tailwind CSS](https://img.shields.io/badge/Tailwind-v4-38bdf8)](https://tailwindcss.com/)
-[![MapLibre GL JS](https://img.shields.io/badge/MapLibre-5.9-blue)](https://maplibre.org/)
+[![MapLibre GL JS](https://img.shields.io/badge/MapLibre-5.13-blue)](https://maplibre.org/)
 
 ## 概要
 

--- a/next.config.js
+++ b/next.config.js
@@ -59,6 +59,16 @@ const nextConfig = {
   // 静的エクスポート（Cloudflare Pages用）
   output: "export",
 
+  // 本番ビルド時にconsole.logを自動削除（console.errorは残す）
+  compiler: {
+    removeConsole:
+      process.env.NODE_ENV === "production"
+        ? {
+            exclude: ["error", "warn"], // エラーと警告は残す
+          }
+        : false,
+  },
+
   // 画像最適化（静的エクスポート時は無効）
   images: {
     unoptimized: true,


### PR DESCRIPTION
## Summary
README.mdのバージョン情報を更新し、本番ビルド時にconsole.logを自動削除する設定を追加しました。

## Changes
- ✅ README.mdのバージョン情報更新
  - Next.js: 15 → 16
  - MapLibre GL JS: 5.9 → 5.13
- ✅ next.config.jsにconsole.log自動削除設定追加
  - 本番ビルド時のみ有効（`NODE_ENV === "production"`）
  - `console.error`と`console.warn`は残す（エラートラッキングのため）
  - `console.log`のみ削除

## 効果
- 本番ビルドのバンドルサイズが削減される
- デバッグ用のconsole.logが本番環境に残らない
- エラーログは引き続き記録される

## Testing
- [x] Lintチェック通過
- [x] バージョン情報の確認