### PR TITLE
feat(map): Add MapLibre Vector Tiles support for offline maps

### DIFF
--- a/.docs/04-phase-mvp.md
+++ b/.docs/04-phase-mvp.md
@@ -707,11 +707,11 @@ Error: Multiple versions of pnpm specified:
 
 ## 📝 既知の問題・制限事項
 
-### 制限事項（2025-11-28時点）
+### 制限事項（2025-12-01時点）
 
-1. **完全オフライン未対応**
-   - 地図タイルはオンライン必須
-   - MapLibre Vector Tiles 化で将来対応可能
+1. **完全オフライン対応（実装中）**
+   - ✅ MapLibre Vector Tiles対応を実装中（Issue #188）
+   - Vector TilesをService Workerでキャッシュし、完全オフライン環境でも地図を表示可能に
 
 **注記:** 以下の機能は Phase 5-8 で実装済み：
 - ✅ 検索機能（避難所名・住所で検索）

--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,66 @@ const withPWA = require("@ducanh2912/next-pwa").default({
   skipWaiting: false, // ユーザーが手動で更新を承認できるようにする
   disable: process.env.NODE_ENV === "development",
   runtimeCaching: [
+    // Vector Tiles (MapLibre Demo Tiles)
+    {
+      urlPattern: /^https:\/\/demotiles\.maplibre\.org\/.*/i,
+      handler: "CacheFirst",
+      options: {
+        cacheName: "maplibre-vector-tiles",
+        expiration: {
+          maxEntries: 2000, // Vector Tilesは軽量なので多めにキャッシュ
+          maxAgeSeconds: 60 * 60 * 24 * 30, // 30日
+        },
+      },
+    },
+    // Vector Tiles (.pbf files)
+    {
+      urlPattern: /\.pbf$/i,
+      handler: "CacheFirst",
+      options: {
+        cacheName: "vector-tiles",
+        expiration: {
+          maxEntries: 2000,
+          maxAgeSeconds: 60 * 60 * 24 * 30, // 30日
+        },
+      },
+    },
+    // 地図スタイルJSON
+    {
+      urlPattern: /\/style\.json$/i,
+      handler: "StaleWhileRevalidate",
+      options: {
+        cacheName: "map-styles",
+        expiration: {
+          maxEntries: 10,
+          maxAgeSeconds: 60 * 60 * 24 * 7, // 7日
+        },
+      },
+    },
+    // フォント、スプライトなどの地図アセット
+    {
+      urlPattern: /\/fonts\/.*/i,
+      handler: "CacheFirst",
+      options: {
+        cacheName: "map-fonts",
+        expiration: {
+          maxEntries: 100,
+          maxAgeSeconds: 60 * 60 * 24 * 30, // 30日
+        },
+      },
+    },
+    {
+      urlPattern: /\/sprite.*\.(?:png|json)$/i,
+      handler: "CacheFirst",
+      options: {
+        cacheName: "map-sprites",
+        expiration: {
+          maxEntries: 20,
+          maxAgeSeconds: 60 * 60 * 24 * 30, // 30日
+        },
+      },
+    },
+    // 旧ラスタタイル（後方互換性のため残す）
     {
       urlPattern: /^https:\/\/tile\.openstreetmap\.jp\/.*/i,
       handler: "CacheFirst",
@@ -26,6 +86,7 @@ const withPWA = require("@ducanh2912/next-pwa").default({
         },
       },
     },
+    // 画像ファイル
     {
       urlPattern: /\.(?:png|jpg|jpeg|svg|gif|webp)$/i,
       handler: "CacheFirst",
@@ -37,6 +98,7 @@ const withPWA = require("@ducanh2912/next-pwa").default({
         },
       },
     },
+    // GeoJSONデータ
     {
       urlPattern: /\.geojson$/i,
       handler: "StaleWhileRevalidate",

--- a/src/types/map.ts
+++ b/src/types/map.ts
@@ -13,13 +13,16 @@ export interface MapStyle {
 }
 
 /**
- * 利用可能な地図スタイル一覧（標準のみ）
+ * 利用可能な地図スタイル一覧（Vector Tiles対応）
  */
 export const MAP_STYLES: Record<MapStyleType, MapStyle> = {
   standard: {
     id: 'standard',
     name: '標準',
-    url: 'https://tile.openstreetmap.jp/styles/osm-bright-ja/style.json',
+    // MapLibre Demo Tiles (Vector Tiles) - 無料、オフラインキャッシュ対応
+    url: 'https://demotiles.maplibre.org/style.json',
+    // 将来的に国土地理院のベクトルタイルに切り替え可能:
+    // url: 'https://cyberjapandata.gsi.go.jp/xyz/std/{z}/{x}/{y}.pbf',
   },
 };
 


### PR DESCRIPTION
## Summary
MapLibre Vector Tiles対応を実装しました。完全オフライン環境でも地図を表示できるようになります。

## Changes
- ✅ Vector Tilesプロバイダーの選定（MapLibre Demo Tiles）
- ✅ 地図スタイルをVector Tiles対応に変更
- ✅ Service WorkerでVector Tilesをキャッシュ
  - `.pbf`ファイル（Vector Tiles）
  - `style.json`（地図スタイル）
  - フォント、スプライトなどのアセット
- ✅ ドキュメント更新

## 技術的詳細

### Vector Tilesの利点
- ラスタタイルより軽量
- ズームレベルに応じて自動的に詳細度が変わる
- スタイルのカスタマイズが容易
- オフラインキャッシュに最適

### キャッシュ戦略
- **Vector Tiles (.pbf)**: CacheFirst、2000エントリ、30日間
- **スタイルJSON**: StaleWhileRevalidate、10エントリ、7日間
- **フォント・スプライト**: CacheFirst、適切なサイズ制限

### 将来の拡張
- 国土地理院のベクトルタイルへの切り替えも可能（コメントに記載済み）

## Testing
- [x] Lintチェック通過
- [ ] オンライン環境での動作確認
- [ ] オフライン環境での動作確認
- [ ] キャッシュサイズの確認

## Related
Closes #188