### PR TITLE
feat(map): Switch to GSI standard map (raster tiles)

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,14 +4,14 @@ const withPWA = require("@ducanh2912/next-pwa").default({
   skipWaiting: false, // ユーザーが手動で更新を承認できるようにする
   disable: process.env.NODE_ENV === "development",
   runtimeCaching: [
-    // Vector Tiles (MapLibre Demo Tiles)
+    // 国土地理院標準地図（ラスタタイル）
     {
-      urlPattern: /^https:\/\/demotiles\.maplibre\.org\/.*/i,
+      urlPattern: /^https:\/\/cyberjapandata\.gsi\.go\.jp\/xyz\/std\/.*/i,
       handler: "CacheFirst",
       options: {
-        cacheName: "maplibre-vector-tiles",
+        cacheName: "gsi-raster-tiles",
         expiration: {
-          maxEntries: 2000, // Vector Tilesは軽量なので多めにキャッシュ
+          maxEntries: 2000,
           maxAgeSeconds: 60 * 60 * 24 * 30, // 30日
         },
       },

--- a/public/gsi-raster-style.json
+++ b/public/gsi-raster-style.json
@@ -1,0 +1,32 @@
+{
+  "version": 8,
+  "name": "地理院地図（標準地図）",
+  "metadata": {
+    "mapbox:autocomposite": false,
+    "mapbox:type": "template"
+  },
+  "sources": {
+    "gsi-raster": {
+      "type": "raster",
+      "tiles": [
+        "https://cyberjapandata.gsi.go.jp/xyz/std/{z}/{x}/{y}.png"
+      ],
+      "tileSize": 256,
+      "attribution": "<a href='https://maps.gsi.go.jp/development/ichiran.html' target='_blank'>国土地理院</a>",
+      "minzoom": 4,
+      "maxzoom": 18,
+      "bounds": [122, 24, 146, 46]
+    }
+  },
+  "layers": [
+    {
+      "id": "gsi-raster-layer",
+      "type": "raster",
+      "source": "gsi-raster",
+      "paint": {
+        "raster-opacity": 1
+      }
+    }
+  ]
+}
+

--- a/src/types/map.ts
+++ b/src/types/map.ts
@@ -13,16 +13,15 @@ export interface MapStyle {
 }
 
 /**
- * 利用可能な地図スタイル一覧（Vector Tiles対応）
+ * 利用可能な地図スタイル一覧（国土地理院標準地図）
  */
 export const MAP_STYLES: Record<MapStyleType, MapStyle> = {
   standard: {
     id: 'standard',
     name: '標準',
-    // MapLibre Demo Tiles (Vector Tiles) - 無料、オフラインキャッシュ対応
-    url: 'https://demotiles.maplibre.org/style.json',
-    // 将来的に国土地理院のベクトルタイルに切り替え可能:
-    // url: 'https://cyberjapandata.gsi.go.jp/xyz/std/{z}/{x}/{y}.pbf',
+    // 国土地理院標準地図（ラスタタイル）- 日本語対応、無料、安定
+    // カスタムスタイルJSONを使用（public/gsi-raster-style.json）
+    url: '/gsi-raster-style.json',
   },
 };
 


### PR DESCRIPTION
## Summary
国土地理院の標準地図（ラスタタイル）に切り替えました。

## Changes
- ✅ MapLibre Demo Tiles → 国土地理院標準地図に変更
- ✅ カスタムスタイルJSONを作成（\`public/gsi-raster-style.json\`）
- ✅ Service Workerのキャッシュ設定を更新（国土地理院タイル用）

## 理由
- 国土地理院のベクトルタイルの公式スタイルJSONが提供されていない
- 国土地理院のラスタタイルは日本語対応で安定している
- 無料で商用利用可能
- オフラインキャッシュ対応

## 注意事項
- ラスタタイルを使用（ベクトルタイルではない）
- オフラインキャッシュは引き続き動作
- 将来的にベクトルタイルのスタイルJSONが提供されたら切り替え可能

## Testing
- [x] Lintチェック通過
- [ ] 地図表示の確認
- [ ] オフライン動作の確認

Related to #188