### PR TITLE
chore(release): Bump version to 0.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "naruto-shelter-map",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "description": "徳島県鳴門市の避難所を地図上に可視化するPWAアプリ（2025年最新技術）",
   "author": "Yusaku Matsukawa",


### PR DESCRIPTION
## Summary
パッチバージョンアップ: 0.2.0 → 0.2.1

## Changes
- Update package.json version to 0.2.1
- Create Git tag v0.2.1

## Recent Updates Included
- Documentation updates (remove version numbers)
- Next.js 16.1.1 update
- Dependency updates (React 19.2.3, MapLibre 5.15.0, etc.)
- Node.js 20 → 22 update
- Shelter data update (151 shelters, name mapping fix)

## Release Notes
This patch release includes:
- Documentation improvements
- Dependency updates for security and compatibility
- Data updates from 国土地理院
- Node.js 22 support