### PR TITLE
fix(map): Preserve zoom when selecting shelter

### DIFF
--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -80,10 +80,11 @@ function MapController({
 
     const [lng, lat] = shelter.geometry.coordinates;
 
-    // 地図を滑らかに移動（ズームレベルを14に調整）
+    // 地図を滑らかに移動（現在のズームは維持）
+    const currentZoom = map.getZoom();
     map.flyTo({
       center: [lng, lat],
-      zoom: 14,
+      zoom: currentZoom,
       duration: 1000,
     });
   }, [selectedShelterId, shelters, map]);


### PR DESCRIPTION
## Summary
避難所マーカー選択時に地図の縮尺（ズーム）が固定値に変更されてしまう挙動を修正しました。

## Background
`MapController` が `flyTo({ ..., zoom: 14 })` を行っており、避難所をクリックするたびにズームが14へ変更されていました。

## Changes
- `src/components/map/Map.tsx`
  - 選択時の `flyTo` で **現在のズームを維持**（`map.getZoom()` を使用）

## Test
- [x] `nr lint`
- [x] `nr type-check`
- [x] `nr build`

Closes #232