### PR TITLE
fix(release): Fix YAML syntax in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,8 @@ jobs:
           
           if [ -z "$PREVIOUS_TAG" ]; then
             # 初回リリース
-            NOTES="## 🎉 初回リリース v${TAG_VERSION}
+            NOTES="$(cat <<EOF
+## 🎉 初回リリース v${TAG_VERSION}
 
 ### 主な機能
 - 📍 避難所の位置表示
@@ -83,11 +84,14 @@ jobs:
 - React 19
 - MapLibre GL JS 5.13
 - Tailwind CSS v4
-- TypeScript 5.6"
+- TypeScript 5.6
+EOF
+)"
           else
             # 変更履歴を生成
             PREVIOUS_TAG_SHORT=${PREVIOUS_TAG#v}
-            NOTES="## 📦 リリース v${TAG_VERSION}
+            NOTES="$(cat <<EOF
+## 📦 リリース v${TAG_VERSION}
 
 ### 変更内容
 
@@ -96,7 +100,9 @@ $(git log ${PREVIOUS_TAG}..${CURRENT_TAG} --pretty=format:'- %s (%h)' --no-merge
 \`\`\`
 
 ### 完全な変更履歴
-[Compare ${PREVIOUS_TAG}...v${TAG_VERSION}](https://github.com/${{ github.repository }}/compare/${PREVIOUS_TAG}...v${TAG_VERSION})"
+[Compare ${PREVIOUS_TAG}...v${TAG_VERSION}](https://github.com/${{ github.repository }}/compare/${PREVIOUS_TAG}...v${TAG_VERSION})
+EOF
+)"
           fi
           
           echo "notes<<EOF" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
`release.yml` がYAML構文エラーで無効化されていたため修正しました。

## Root cause
`run: |` 内で `NOTES="...` の複数行文字列を直書きしており、YAMLのパース対象になって `Invalid workflow file`（L73）になっていました。

## Changes
- `.github/workflows/release.yml`
  - リリースノート生成の `NOTES` を heredoc（`cat <<EOF`）に変更してYAMLが壊れないように修正

## Test
- [x] `nr lint`
- [x] `nr type-check`
- [x] `nr build`

Fixes: release workflow parse error