### PR TITLE
docs: データ更新フローを地理院タイルAPI自動取得に合わせて更新

### DIFF
--- a/.docs/00-MASTER-PLAN.md
+++ b/.docs/00-MASTER-PLAN.md
@@ -301,7 +301,7 @@ naruto-shelter-map/
 
 #### 注意事項
 
-⚠️ 国土地理院は避難所データの直接APIを提供していないため、実際の更新は手動ダウンロードが必要です。
+避難所データは **国土地理院 地理院タイルAPI** から **毎週月曜 3:00 JST** に自動取得されます。手動実行（任意の GeoJSON ファイルを指定）も可能です。
 
 ---
 
@@ -309,10 +309,10 @@ naruto-shelter-map/
 
 ```mermaid
 graph LR
-    A[国土地理院API] -->|毎日3:00 JST| B[GitHub Actions]
-    B -->|ETLスクリプト実行| C[鳴門市データ抽出]
-    C -->|GeoJSON生成| D[public/data/shelters.geojson]
-    D -->|Git Commit & Push| E[GitHub Repository]
+    A[国土地理院<br/>地理院タイルAPI] -->|毎週月曜 3:00 JST| B[GitHub Actions]
+    B -->|fetch-shelters.ts| C[対応地域データ抽出]
+    C -->|検証・ジオコーディング| D[public/data/shelters.geojson]
+    D -->|PR作成・マージ| E[GitHub Repository]
     E -->|自動デプロイ| F[Cloudflare Pages]
     F -->|CDN配信| G[ユーザー]
     G -->|Service Worker| H[オフラインキャッシュ]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,7 +100,7 @@ naruto-shelter-map/
 │   └── README.md                 # ドキュメントインデックス
 ├── .github/
 │   └── workflows/
-│       └── update-shelters.yml   # データ自動更新ワークフロー
+│       └── update-data.yml       # データ自動更新ワークフロー
 ├── public/
 │   ├── data/
 │   │   └── shelters.geojson      # 避難所データ（自動更新）


### PR DESCRIPTION
## Summary
ドキュメントを現状のデータ更新仕様（地理院タイルAPIから毎週月曜 3:00 JST に自動取得）に合わせて更新しました。

## Changes
- **README.md**
  - データ更新フロー図を「手動ダウンロード」から「地理院タイルAPI・毎週月曜 3:00 JST」に変更
  - データ更新の仕組みの説明を自動取得ベースに修正
  - 更新手順を「自動更新（通常）」と「手動実行（任意）」に整理
  - 検証コマンドを `pnpm validate:shelters` に統一
- **.docs/00-MASTER-PLAN.md**
  - Phase 5 注意事項を「自動取得・手動実行も可能」に修正
  - データフロー図を毎週月曜・地理院タイルAPI・PR 作成フローに合わせて更新
- **AGENTS.md**
  - ディレクトリ構造のワークフロー名を `update-data.yml` に修正

## Test Plan
- [x] `pnpm lint` 通過
- [x] `pnpm type-check` 通過
- [x] 記載内容が現行の `update-data.yml` の挙動と一致することを確認

Made with [Cursor](https://cursor.com)