### PR TITLE
feat(data): Add manual data refresh and offline feedback (#258)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -34,7 +34,16 @@ const ShelterMap = dynamic(
 );
 
 function HomePageContent() {
-  const { data, isLoading, error, retry } = useShelters();
+  const {
+    data,
+    isLoading,
+    error,
+    retry,
+    refresh,
+    isRefreshing,
+    refreshError,
+    clearRefreshError,
+  } = useShelters();
   const {
     position,
     state: geolocationState,
@@ -117,6 +126,43 @@ function HomePageContent() {
 
   return (
     <>
+      {/* データ更新失敗時のメッセージ（オフライン等） */}
+      {refreshError && (
+        <div
+          role="alert"
+          aria-live="polite"
+          className="fixed bottom-4 left-4 right-4 z-50 flex items-center justify-between gap-3 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 shadow-lg sm:left-auto sm:right-4 sm:max-w-sm"
+        >
+          <p className="text-sm text-amber-900">
+            {refreshError.message.includes('fetch') ||
+            refreshError.message.includes('Network')
+              ? 'オフラインのため更新できません'
+              : refreshError.message}
+          </p>
+          <button
+            type="button"
+            onClick={clearRefreshError}
+            className="flex-shrink-0 rounded p-1 text-amber-700 hover:bg-amber-100 focus:outline-none focus:ring-2 focus:ring-amber-400"
+            aria-label="閉じる"
+          >
+            <svg
+              className="h-5 w-5"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+      )}
+
       {/* モバイルレイアウト（< 1024px） */}
       <div className="flex h-screen flex-col lg:hidden">
         {/* 地図エリア（フルスクリーン） */}
@@ -130,6 +176,8 @@ function HomePageContent() {
             geolocationState={geolocationState}
             geolocationError={geolocationError}
             onGetCurrentPosition={getCurrentPosition}
+            onRefresh={refresh}
+            isRefreshing={isRefreshing}
           />
         </main>
       </div>
@@ -147,6 +195,39 @@ function HomePageContent() {
               <h1 className="flex-shrink-0 text-2xl font-bold text-gray-900">
                 避難所マップ
               </h1>
+              <button
+                type="button"
+                onClick={() => void refresh()}
+                disabled={isRefreshing}
+                className="flex items-center gap-1.5 rounded-lg border border-gray-300 bg-white px-2.5 py-1.5 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2 disabled:opacity-60"
+                aria-label="避難所データを最新に更新"
+                title="通信して最新の避難所データを取得します（通常はキャッシュのみで通信しません）"
+              >
+                {isRefreshing ? (
+                  <span
+                    className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-gray-300 border-t-blue-600"
+                    aria-hidden
+                  />
+                ) : (
+                  <svg
+                    className="h-3.5 w-3.5"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                    aria-hidden
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+                    />
+                  </svg>
+                )}
+                <span className="hidden sm:inline">
+                  {isRefreshing ? '更新中...' : 'データを更新'}
+                </span>
+              </button>
             </div>
             <p className="text-sm text-gray-700">
               {listFilter === 'favorites'

--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -30,6 +30,9 @@ interface MapProps {
   geolocationState?: GeolocationState;
   geolocationError?: GeolocationError | null;
   onGetCurrentPosition?: () => void;
+  /** モバイル用: 避難所データを最新に更新（押したときだけ通信） */
+  onRefresh?: () => void;
+  isRefreshing?: boolean;
 }
 
 // 避難所種別に応じたマーカー色
@@ -118,6 +121,8 @@ export function ShelterMap({
   geolocationState,
   geolocationError,
   onGetCurrentPosition,
+  onRefresh,
+  isRefreshing = false,
 }: MapProps) {
   const [selectedShelter, setSelectedShelter] = useState<ShelterFeature | null>(
     null
@@ -237,6 +242,45 @@ export function ShelterMap({
         />
         {/* フィルタボタン（モバイルのみ） */}
         <FilterButton />
+
+        {/* データを更新ボタン（モバイルのみ） */}
+        {onRefresh && (
+          <div className="absolute left-4 top-20 z-10 lg:hidden">
+            <button
+              type="button"
+              onClick={() => onRefresh()}
+              disabled={isRefreshing}
+              className="flex items-center gap-2 rounded-full border border-gray-200 bg-white px-3 py-2 shadow-lg transition-all hover:bg-gray-50 hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-60"
+              aria-label="避難所データを最新に更新"
+              title="通信して最新の避難所データを取得します"
+            >
+              {isRefreshing ? (
+                <span
+                  className="h-4 w-4 animate-spin rounded-full border-2 border-gray-300 border-t-blue-600"
+                  aria-hidden
+                />
+              ) : (
+                <svg
+                  className="h-4 w-4 text-gray-600"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+                  />
+                </svg>
+              )}
+              <span className="text-sm font-medium text-gray-700">
+                {isRefreshing ? '更新中...' : 'データを更新'}
+              </span>
+            </button>
+          </div>
+        )}
 
         {markers}
 

--- a/src/hooks/useShelters.ts
+++ b/src/hooks/useShelters.ts
@@ -1,23 +1,49 @@
 import { useCallback, useEffect, useState } from 'react';
 import type { ShelterGeoJSON } from '@/types/shelter';
 
+/** キャッシュをバイパスして最新を取得する用の URL（SW プリキャッシュにヒットさせない） */
+function getSheltersUrl(cacheBust = false): string {
+  if (cacheBust) {
+    return `/data/shelters.geojson?t=${Date.now()}`;
+  }
+  return '/data/shelters.geojson';
+}
+
+const REFRESH_ERROR_DURATION_MS = 6000;
+
 export function useShelters(): {
   data: ShelterGeoJSON | null;
   isLoading: boolean;
   error: Error | null;
   retry: () => void;
+  /** 通信して最新データを取得（押したときだけ。通常はキャッシュのみで通信しない） */
+  refresh: () => Promise<void>;
+  isRefreshing: boolean;
+  /** refresh 失敗時のメッセージ（オフライン等）。数秒で自動クリア。 */
+  refreshError: Error | null;
+  clearRefreshError: () => void;
 } {
   const [data, setData] = useState<ShelterGeoJSON | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
   const [retryCount, setRetryCount] = useState(0);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [refreshError, setRefreshError] = useState<Error | null>(null);
 
-  const fetchShelters = useCallback(async () => {
+  const clearRefreshError = useCallback((): void => {
+    setRefreshError(null);
+  }, []);
+
+  const fetchShelters = useCallback(async (bypassCache: boolean) => {
+    const url = getSheltersUrl(bypassCache);
     try {
-      setIsLoading(true);
+      if (!bypassCache) setIsLoading(true);
       setError(null);
+      if (bypassCache) setRefreshError(null);
 
-      const response = await fetch('/data/shelters.geojson');
+      const response = await fetch(url, {
+        cache: bypassCache ? 'no-store' : 'default',
+      });
 
       if (!response.ok) {
         throw new Error(
@@ -32,22 +58,42 @@ export function useShelters(): {
         err instanceof Error
           ? err.message
           : '避難所データの読み込みに失敗しました';
-      setError(new Error(errorMessage));
-      setData(null);
+      const errorObj = new Error(errorMessage);
+      setError(errorObj);
+      if (!bypassCache) setData(null);
+      if (bypassCache) {
+        setRefreshError(errorObj);
+        setTimeout(() => setRefreshError(null), REFRESH_ERROR_DURATION_MS);
+      }
       console.error('Failed to fetch shelters:', err);
     } finally {
-      setIsLoading(false);
+      if (!bypassCache) setIsLoading(false);
+      if (bypassCache) setIsRefreshing(false);
     }
   }, []);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: retryカウンターによる再フェッチのためretryCountが必要
   useEffect(() => {
-    fetchShelters();
+    fetchShelters(false);
   }, [fetchShelters, retryCount]);
 
   const retry = useCallback((): void => {
     setRetryCount((prev) => prev + 1);
   }, []);
 
-  return { data, isLoading, error, retry };
+  const refresh = useCallback(async (): Promise<void> => {
+    setIsRefreshing(true);
+    await fetchShelters(true);
+  }, [fetchShelters]);
+
+  return {
+    data,
+    isLoading,
+    error,
+    retry,
+    refresh,
+    isRefreshing,
+    refreshError,
+    clearRefreshError,
+  };
 }


### PR DESCRIPTION
## Summary
Issue #258 地図データ更新ボタン / キャッシュで古くなる問題への対策です。オフライン優先のため、**通常は通信せず、ユーザーが「データを更新」を押したときだけ**ネットワークで最新を取得します。

## Changes

### 既存（前回実装分）
- `useShelters`: `refresh()` で `?t=timestamp` + `cache: 'no-store'` により SW プリキャッシュをバイパスして取得
- デスクトップ: サイドバーヘッダーに「データを更新」ボタン

### 今回追加
- **モバイル**: 地図上（フィルタボタン下）に「データを更新」ボタン（`Map` に `onRefresh`, `isRefreshing` を渡す）
- **オフライン時フィードバック**: refresh 失敗時に `refreshError` をセットし、画面下部に `role="alert"` `aria-live="polite"` のバナーで「オフラインのため更新できません」を表示。閉じるボタンまたは約6秒で自動クリア。

## Files
- `src/hooks/useShelters.ts` - refreshError, clearRefreshError, 自動クリア
- `src/components/map/Map.tsx` - onRefresh, isRefreshing, モバイル用更新ボタン
- `src/app/page.tsx` - refreshError バナー表示、モバイル ShelterMap に onRefresh 渡す

Closes #258

Made with [Cursor](https://cursor.com)