### PR TITLE
docs: align documentation with actual code and file names

### DIFF
--- a/.docs/00-MASTER-PLAN.md
+++ b/.docs/00-MASTER-PLAN.md
@@ -119,7 +119,7 @@ naruto-shelter-map/
 │   └── manifest.json           # PWA Manifest
 │
 ├── scripts/
-│   └── fetch_shelters.ts       # データ取得ETLスクリプト
+│   └── fetch-shelters.ts       # データ取得ETLスクリプト
 │
 ├── src/
 │   ├── App.tsx                 # ルートコンポーネント
@@ -140,7 +140,7 @@ naruto-shelter-map/
 │   │   └── useGeolocation.ts   # 位置情報
 │   │
 │   ├── lib/                    # ユーティリティ
-│   │   ├── geojson.ts          # GeoJSON処理
+│   │   ├── geo.ts              # 座標・距離等のユーティリティ
 │   │   └── maplibre.ts         # MapLibre設定
 │   │
 │   └── types/                  # TypeScript型定義
@@ -294,7 +294,7 @@ naruto-shelter-map/
 
 #### タスク
 
-- [x] `scripts/fetch_shelters.ts` 実装
+- [x] `scripts/fetch-shelters.ts` 実装
 - [x] GitHub Actions ワークフロー作成（毎週月曜 3:00 JST）
 - [x] 自動デプロイ設定
 - [x] データ検証機能実装

--- a/.docs/02-phase-ai-env.md
+++ b/.docs/02-phase-ai-env.md
@@ -134,7 +134,7 @@ naruto-shelter-map/
 │   └── icons/                  # PWAアイコン
 │
 ├── scripts/
-│   └── fetch_shelters.ts       # データ取得ETLスクリプト
+│   └── fetch-shelters.ts       # データ取得ETLスクリプト
 │
 ├── src/
 │   ├── app/                    # Next.js App Router
@@ -156,7 +156,7 @@ naruto-shelter-map/
 │   │   └── useGeolocation.ts
 │   │
 │   ├── lib/                    # ユーティリティ
-│   │   ├── geojson.ts
+│   │   ├── geo.ts
 │   │   └── maplibre.ts
 │   │
 │   └── types/                  # TypeScript型定義

--- a/.docs/05-phase-enhancements.md
+++ b/.docs/05-phase-enhancements.md
@@ -152,7 +152,7 @@ function toRad(degrees: number): number {
 **成果物:**
 - `scripts/fetch-shelters.ts`（ETLスクリプト）
 - `.github/workflows/update-shelters.yml`
-- `scripts/validate-geojson.ts`（データ検証）
+- `scripts/validate-shelters.ts`（データ検証）
 
 **技術仕様:**
 
@@ -227,7 +227,7 @@ jobs:
         run: pnpm tsx scripts/fetch-shelters.ts
 
       - name: Validate GeoJSON
-        run: pnpm tsx scripts/validate-geojson.ts
+        run: pnpm tsx scripts/validate-shelters.ts
 
       - name: Check for changes
         id: changes

--- a/.docs/README.md
+++ b/.docs/README.md
@@ -103,7 +103,7 @@ cat .docs/03-phase-dev-env.md
 **詳細:** MVP完了後に `.docs/05-phase-automation.md` として作成予定
 
 実装内容:
-- `scripts/fetch_shelters.ts` ETLスクリプト
+- `scripts/fetch-shelters.ts` ETLスクリプト
 - GitHub Actions ワークフロー
 - 自動デプロイ設定
 

--- a/.docs/sop/troubleshooting.md
+++ b/.docs/sop/troubleshooting.md
@@ -69,7 +69,7 @@
 
 - `.github/workflows/update-data.yml` のログを確認。
 - 国土地理院 API の仕様変更・障害の有無を確認。
-- `scripts/fetch_shelters.ts` をローカルで実行し、エラー再現する（`tsx scripts/fetch_shelters.ts` 等）。
+- `scripts/fetch-shelters.ts` をローカルで実行し、エラー再現する（`pnpm tsx scripts/fetch-shelters.ts` 等）。
 
 ### 検証スクリプトでエラーになる
 

--- a/.docs/system/data-schema.md
+++ b/.docs/system/data-schema.md
@@ -9,7 +9,7 @@
 避難所データは **GeoJSON FeatureCollection** で保持します。
 
 - **ファイル:** `public/data/shelters.geojson`
-- **更新:** GitHub Actions（毎週月曜 3:00 JST）で `scripts/fetch_shelters.ts` が国土地理院 API から取得・検証。
+- **更新:** GitHub Actions（毎週月曜 3:00 JST）で `scripts/fetch-shelters.ts` が国土地理院 API から取得・検証。
 
 ---
 

--- a/.docs/system/project-structure.md
+++ b/.docs/system/project-structure.md
@@ -28,7 +28,7 @@ naruto-shelter-map/
 │   └── sw.js                       # Service Worker
 │
 ├── scripts/
-│   ├── fetch_shelters.ts           # 国土地理院APIからデータ取得
+│   ├── fetch-shelters.ts           # 国土地理院APIからデータ取得
 │   ├── geocode-shelters.ts         # ジオコーディング
 │   └── validate-shelters.ts        # データ検証
 │

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,28 +112,26 @@ naruto-shelter-map/
 │   ├── main.tsx                  # エントリ（createRoot）
 │   ├── globals.css               # グローバルスタイル（Tailwind v4）
 │   ├── vite-env.d.ts             # Vite クライアント型
-│   ├── components/               # Reactコンポーネント
-│   │   ├── map/
-│   │   │   ├── Map.tsx           # MapLibre地図コンポーネント
-│   │   │   ├── ShelterMarker.tsx # 避難所マーカー
-│   │   │   └── MapControls.tsx   # 地図コントロール
-│   │   ├── search/
-│   │   │   ├── SearchBar.tsx     # 検索バー
-│   │   │   └── SearchResults.tsx # 検索結果
-│   │   └── ui/                   # 共通UIコンポーネント
+│   ├── components/               # Reactコンポーネント（機能別サブフォルダ）
+│   │   ├── map/                 # 地図・マーカー・コントロール
+│   │   ├── shelter/             # 避難所リスト・カード・詳細モーダル
+│   │   ├── filter/              # 災害種別フィルタ
+│   │   ├── pwa/                 # インストール・オフライン表示
+│   │   ├── a11y/                # アクセシビリティ
+│   │   └── ...                  # 詳細は .docs/system/project-structure.md 参照
 │   ├── lib/                      # ユーティリティ・ヘルパー
-│   │   ├── geojson.ts            # GeoJSON処理
+│   │   ├── geo.ts                # 座標・距離等のユーティリティ
 │   │   ├── offline.ts            # オフライン対応
 │   │   └── utils.ts              # 汎用ユーティリティ
 │   ├── types/                    # TypeScript型定義
 │   │   ├── shelter.ts            # 避難所データ型
 │   │   └── map.ts                # 地図関連型
 │   └── hooks/                    # カスタムフック
-│       ├── useMap.ts             # 地図操作
 │       ├── useShelters.ts        # 避難所データ取得
-│       └── useOffline.ts         # オフライン状態検出
+│       ├── useOffline.ts         # オフライン状態検出
+│       └── ...                   # 詳細は .docs/system/project-structure.md 参照
 ├── scripts/                      # ビルド・データ処理スクリプト
-│   └── fetch_shelters.ts         # 国土地理院APIから避難所データ取得
+│   └── fetch-shelters.ts         # 国土地理院APIから避難所データ取得
 ├── index.html                    # エントリ HTML（Vite）
 ├── vite.config.ts                # Vite 設定（PWA 含む）
 ├── biome.json                    # Biome設定（Lint + Format）
@@ -245,7 +243,7 @@ components/
     Map.tsx              # PascalCase（React コンポーネント）
     ShelterMarker.tsx
 lib/
-  geojson.ts           # camelCase（ユーティリティ）
+  geo.ts               # camelCase（ユーティリティ）
   offline.ts
 types/
   shelter.ts           # camelCase（型定義）
@@ -283,8 +281,8 @@ import { useState } from "react";
 import maplibregl from "maplibre-gl";
 
 // 2. 内部モジュール（@/* エイリアス使用）
-import { ShelterMarker } from "@/components/map/ShelterMarker";
-import { fetchShelters } from "@/lib/geojson";
+import { Map } from "@/components/map/Map";
+import { useShelters } from "@/hooks/useShelters";
 import type { ShelterFeature } from "@/types/shelter";
 
 // 3. スタイル

--- a/README.md
+++ b/README.md
@@ -99,10 +99,10 @@
         "name": "○○小学校",
         "type": "指定避難所",
         "address": "徳島県鳴門市○○町1-1",
-        "disaster_types": ["洪水", "津波"],
+        "disasterTypes": ["洪水", "津波"],
         "capacity": 800,
         "source": "国土地理院オープンデータ",
-        "updated_at": "2025-10-15"
+        "updatedAt": "2025-10-15"
       }
     }
   ]
@@ -115,7 +115,7 @@
 
 ### 必要な環境
 
-- Node.js 22 以上
+- **Node.js 24 以上**（`package.json` の `engines` および `.nvmrc` に準拠）
 - **pnpm 9 以上**
 
 ### インストール手順


### PR DESCRIPTION
## Summary
コード・実ファイルとドキュメントの不整合を解消しました。

## Changes

### スクリプト名の統一
- `fetch_shelters.ts` → `fetch-shelters.ts`（アンダースコアをハイフンに）
- `validate-geojson.ts` → `validate-shelters.ts`（実際のファイル名に合わせる）

### README.md
- **Node.js**: 「22 以上」→「24 以上」（`package.json` の `engines` と `.nvmrc` に準拠）
- **データ構造例**: `disaster_types` / `updated_at` を `disasterTypes` / `updatedAt` に（実際の GeoJSON と camelCase に合わせる）

### AGENTS.md
- 存在しない `src/lib/geojson.ts` を `src/lib/geo.ts` に修正
- Import 例を `@/lib/geojson` から `useShelters` / `Map` など実在する参照に変更
- ディレクトリ構造を実態に合わせて更新（components/hooks の記載を簡略化し、`.docs/system/project-structure.md` を参照する形に）

### .docs 一式
- `project-structure.md`, `data-schema.md`, `troubleshooting.md`, `05-phase-enhancements.md`, `00-MASTER-PLAN.md`, `02-phase-ai-env.md`, `.docs/README.md` 内のスクリプト名・lib 参照を上記に合わせて修正

## Test
- [x] `pnpm lint` 通過
- [x] `pnpm type-check` 通過
- ドキュメントのみの変更のためビルドは未実行（必要なら CI で確認）

Made with [Cursor](https://cursor.com)