### PR TITLE
docs: minor doc updates (dates, next steps, external links)

### DIFF
--- a/.docs/00-MASTER-PLAN.md
+++ b/.docs/00-MASTER-PLAN.md
@@ -21,7 +21,7 @@
 1. **オフラインファースト**: 電波がなくても避難所情報にアクセス可能
 2. **オープンデータ活用**: 国土地理院・国土交通省の公開データを利用
 3. **最新 Web 技術**: Vite 6, React 19, Tailwind CSS v4, TypeScript, MapLibre GL JS（2026 年 2 月に Next.js から Vite に移行、ADR-003）
-4. **自動更新**: GitHub Actions で毎日データを自動更新
+4. **自動更新**: GitHub Actions で毎週月曜 3:00 JST にデータを自動更新
 5. **オープンソース**: MIT License で誰でも利用・改変可能
 
 ---

--- a/.docs/PRODUCT-ROADMAP.md
+++ b/.docs/PRODUCT-ROADMAP.md
@@ -355,7 +355,7 @@ PWA対応      UX改善     多機能化
 
 ### 外部リソース
 
-- [Next.js Documentation](https://nextjs.org/docs)
+- [Vite Documentation](https://vitejs.dev/)
 - [React Documentation](https://react.dev/)
 - [MapLibre GL JS](https://maplibre.org/maplibre-gl-js/docs/)
 - [PWA Best Practices](https://web.dev/progressive-web-apps/)
@@ -378,8 +378,8 @@ PWA対応      UX改善     多機能化
 
 ## 🎯 Next Steps
 
-1. **Phase 6（PWA 対応）** の詳細計画策定 → `.docs/06-phase-pwa.md`
-2. Service Worker 実装開始
-3. PWA Lighthouse 監査
+**Phase 0–8 完了済み。** 次の検討事項:
 
-**現在の最優先タスク:** Phase 6 - PWA 対応・オフライン強化
+1. **多言語対応** - 英語 / やさしい日本語
+2. **他市町村対応** - 徳島県全域など
+3. **ドキュメント更新サイクル** - ロードマップの定期見直し（進捗・KPI・優先度）

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 >
 > このドキュメントは、AI Coding Agents（Claude, Cursor, GitHub Copilot, etc.）がプロジェクトを理解し、適切なコードを生成するための標準規格です。
 
-**Last Updated:** 2025-12-27
+**Last Updated:** 2026-02-14
 **Project Version:** 1.0.0
 **AI Agent Compatibility:** Claude Code, Cursor, GitHub Copilot, Windsurf
 


### PR DESCRIPTION
## Summary
軽いドキュメント更新です。

## Changes
- **AGENTS.md**: Last Updated `2025-12-27` → `2026-02-14`
- **PRODUCT-ROADMAP.md**: Next Steps を現状に合わせて更新（Phase 0–8 完了、次の検討: 多言語 / 他市町村 / ドキュメント更新サイクル）
- **PRODUCT-ROADMAP.md**: 外部リソースの Next.js リンクを Vite に差し替え
- **00-MASTER-PLAN.md**: データ自動更新の説明を「毎日」→「毎週月曜 3:00 JST」に修正

## Test
ドキュメントのみの変更のため、lint/type-check は不要。

Made with [Cursor](https://cursor.com)