### PR TITLE
style(map): モバイルUIのボタン配置を改善

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -222,7 +222,7 @@ function HomePageContent({ mainContentId }: { mainContentId: string }) {
             />
           </Suspense>
         </main>
-        <div className="absolute bottom-20 left-4 z-10">
+        <div className="absolute bottom-34 right-4 z-10">
           <ChatFab onClick={() => setChatModalOpen(true)} />
         </div>
       </div>

--- a/src/components/map/CurrentLocationButton.tsx
+++ b/src/components/map/CurrentLocationButton.tsx
@@ -112,7 +112,7 @@ export const CurrentLocationButton: FC<CurrentLocationButtonProps> = ({
       disabled={state === 'loading'}
       className={cn(
         // Googleマップ風: 円形、白背景、影
-        'flex h-11 w-11 items-center justify-center rounded-full bg-white shadow-lg transition-all',
+        'flex h-12 w-12 items-center justify-center rounded-full bg-white shadow-lg transition-all',
         'hover:shadow-xl active:shadow-md',
         'focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2',
         'disabled:cursor-not-allowed disabled:opacity-75',

--- a/src/components/map/FilterButton.tsx
+++ b/src/components/map/FilterButton.tsx
@@ -11,27 +11,25 @@ export function FilterButton() {
 
   return (
     <>
-      {/* フィルタボタン（左上） */}
-      <div className="absolute left-4 top-4 z-10 lg:hidden">
-        <button
-          type="button"
-          onClick={() => setIsOpen(!isOpen)}
-          className={`
-            flex items-center gap-2 rounded-full bg-white px-4 py-2.5 shadow-lg
-            transition-all hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2
-            ${hasActiveFilters ? 'border-2 border-blue-500' : 'border border-gray-200'}
-          `}
-          aria-label="フィルタ"
-          aria-expanded={isOpen}
-        >
-          <span className="text-sm font-medium text-gray-700">フィルタ</span>
-          {hasActiveFilters && (
-            <span className="flex h-5 w-5 items-center justify-center rounded-full bg-blue-500 text-xs font-semibold text-white">
-              {selectedDisasters.length}
-            </span>
-          )}
-        </button>
-      </div>
+      {/* フィルタボタン */}
+      <button
+        type="button"
+        onClick={() => setIsOpen(!isOpen)}
+        className={`
+          flex items-center gap-2 rounded-full bg-white px-4 py-2.5 shadow-lg
+          transition-all hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2
+          ${hasActiveFilters ? 'border-2 border-blue-500' : 'border border-gray-200'}
+        `}
+        aria-label="フィルタ"
+        aria-expanded={isOpen}
+      >
+        <span className="text-sm font-medium text-gray-700">フィルタ</span>
+        {hasActiveFilters && (
+          <span className="flex h-5 w-5 items-center justify-center rounded-full bg-blue-500 text-xs font-semibold text-white">
+            {selectedDisasters.length}
+          </span>
+        )}
+      </button>
 
       {/* フィルタドロワー */}
       {isOpen && (
@@ -43,7 +41,7 @@ export function FilterButton() {
             aria-hidden="true"
           />
           {/* ドロワー */}
-          <div className="absolute left-4 top-20 z-50 w-80 max-w-[calc(100vw-2rem)] rounded-lg bg-white shadow-2xl lg:hidden">
+          <div className="absolute left-4 top-16 z-50 w-80 max-w-[calc(100vw-2rem)] rounded-lg bg-white shadow-2xl lg:hidden">
             <div className="max-h-[calc(100vh-6rem)] overflow-y-auto p-4">
               <DisasterTypeFilter />
             </div>

--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -240,17 +240,15 @@ export function ShelterMap({
           showCompass={false}
           showZoom={true}
         />
-        {/* フィルタボタン（モバイルのみ） */}
-        <FilterButton />
-
-        {/* データを更新ボタン（モバイルのみ） */}
-        {onRefresh && (
-          <div className="absolute left-4 top-20 z-10 lg:hidden">
+        {/* モバイル用: フィルタ + データ更新ボタン（横並び） */}
+        <div className="absolute left-4 top-4 z-10 flex items-center gap-2 lg:hidden">
+          <FilterButton />
+          {onRefresh && (
             <button
               type="button"
               onClick={() => onRefresh()}
               disabled={isRefreshing}
-              className="flex items-center gap-2 rounded-full border border-gray-200 bg-white px-3 py-2 shadow-lg transition-all hover:bg-gray-50 hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-60"
+              className="flex h-10 w-10 items-center justify-center rounded-full border border-gray-200 bg-white shadow-lg transition-all hover:bg-gray-50 hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-60"
               aria-label="避難所データを最新に更新"
               title="通信して最新の避難所データを取得します"
             >
@@ -275,12 +273,9 @@ export function ShelterMap({
                   />
                 </svg>
               )}
-              <span className="text-sm font-medium text-gray-700">
-                {isRefreshing ? '更新中...' : 'データを更新'}
-              </span>
             </button>
-          </div>
-        )}
+          )}
+        </div>
 
         {markers}
 
@@ -406,8 +401,8 @@ export function ShelterMap({
         )}
       </MapGL>
 
-      {/* 現在地ボタン - モバイル: 右下（タブバーの上 = より下に配置）、PC: 右下 */}
-      <div className="absolute bottom-10 right-4 z-10 lg:bottom-10 lg:right-4">
+      {/* 現在地ボタン - モバイル: 右下、PC: 右下 */}
+      <div className="absolute bottom-20 right-4 z-10 lg:bottom-10 lg:right-4">
         <CurrentLocationButton
           onClick={handleLocationButtonClick}
           state={state}

--- a/src/globals.css
+++ b/src/globals.css
@@ -60,4 +60,9 @@
   padding: 8px;
 }
 
-/* モバイルでもナビゲーションコントロールを表示（右上に配置） */
+/* モバイルではズームコントロールを非表示（ピンチ操作で十分） */
+@media (max-width: 1023px) {
+  .maplibregl-ctrl-top-right {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Summary
- モバイル画面のボタン配置を全体的に整理し、視認性・操作性を向上
- フィルタ＋データ更新ボタンを左上に横並び1行にまとめ、更新ボタンをアイコンのみに変更
- チャットFABと現在地ボタンを右下に縦並びでグループ化し、サイズを h-12 に統一
- モバイルでズームコントロールを非表示に（ピンチ操作で十分）

## Test plan
- [ ] モバイルビューポート（390x844）でボタン配置を確認
- [ ] フィルタドロワーの開閉が正常動作することを確認
- [ ] チャットFAB・現在地ボタンのタップが正常動作することを確認
- [ ] データ更新ボタン（アイコンのみ）のタップが正常動作することを確認
- [ ] デスクトップ（lg以上）で既存レイアウトが崩れていないことを確認
- [ ] `pnpm lint` / `pnpm type-check` エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)