### PR TITLE
fix(map): 詳細モーダルを閉じても popover と地図状態を維持

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,7 @@ import {
   useMemo,
   useState,
 } from 'react';
-import { Route, Router, useLocation, useParams } from 'wouter';
+import { Router, useLocation, useRoute } from 'wouter';
 import { SkipLink } from '@/components/a11y/SkipLink';
 import { ChatFab } from '@/components/chat/ChatFab';
 import { ChatModal } from '@/components/chat/ChatModal';
@@ -45,8 +45,8 @@ const MAP_LOADING_FALLBACK = (
 
 function HomePageContent({ mainContentId }: { mainContentId: string }) {
   const [, setLocation] = useLocation();
-  const params = useParams<{ id?: string }>();
-  const shelterIdFromUrl = params?.id ?? null;
+  const [match, params] = useRoute('/shelter/:id');
+  const shelterIdFromUrl = match ? (params.id ?? null) : null;
 
   const {
     data,
@@ -93,8 +93,11 @@ function HomePageContent({ mainContentId }: { mainContentId: string }) {
     [setLocation]
   );
   const closeDetail = useCallback(() => {
+    if (shelterIdFromUrl) {
+      setSelectedShelterIdState(shelterIdFromUrl);
+    }
     setLocation('/');
-  }, [setLocation]);
+  }, [setLocation, shelterIdFromUrl]);
 
   // 存在しない id の場合はトップへリダイレクト
   useEffect(() => {
@@ -431,12 +434,7 @@ function App() {
       <ErrorBoundary>
         <FilterProvider>
           <Router>
-            <Route path="/shelter/:id">
-              <HomePageContent mainContentId={mainContentId} />
-            </Route>
-            <Route path="/">
-              <HomePageContent mainContentId={mainContentId} />
-            </Route>
+            <HomePageContent mainContentId={mainContentId} />
           </Router>
         </FilterProvider>
       </ErrorBoundary>


### PR DESCRIPTION
## Summary
- 詳細モーダルを閉じたときに popover が閉じてしまい、地図のズーム・位置もリセットされる問題を修正
- `HomePageContent` を2つの `<Route>` で別々に描画していたため、URL変更時にコンポーネントが再マウントされていたのが原因
- `useRoute` を使い `HomePageContent` を1回だけ描画する構造に変更し、再マウントを防止

## Test plan
- [ ] マーカークリック → popover 表示 → 「詳細を見る」→ モーダル閉じる → **popover が残り、地図位置が変わらない**こと
- [ ] `/shelter/<valid-id>` に直接アクセス → モーダルが表示されること
- [ ] `/shelter/<invalid-id>` → `/` にリダイレクトされること
- [ ] ブラウザの戻る/進むボタンでエラーが出ないこと

Closes #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)