### PR TITLE
docs: ドメインを naruto-hinan.com に更新

### DIFF
--- a/.docs/cloudflare-pages-setup.md
+++ b/.docs/cloudflare-pages-setup.md
@@ -118,7 +118,7 @@ dist
 ビルド成功後、以下のURLが生成されます：
 
 ```
-https://naruto-shelter-map.pages.dev
+https://naruto-hinan.com
 ```
 
 または
@@ -199,12 +199,12 @@ dist/
 4. **「Continue」** をクリック
 5. 表示されるCNAMEレコードをメモ：
    ```
-   CNAME naruto-shelter.example.com → naruto-shelter-map.pages.dev
+   CNAME naruto-shelter.example.com → naruto-hinan.com
    ```
 6. **既存のドメインのDNS設定**（例: お名前.com、ムームードメインなど）で：
    - レコードタイプ: `CNAME`
    - ホスト名: `naruto-shelter`
-   - 値: `naruto-shelter-map.pages.dev`
+   - 値: `naruto-hinan.com`
    - TTL: `3600`（1時間）
 7. Cloudflare Pagesに戻り、**「Activate domain」** をクリック
 8. DNS伝播を待つ（最大48時間、通常は数分〜数時間）
@@ -346,7 +346,7 @@ npm i -g pnpm && pnpm install && pnpm build
 - ✅ HTTPSでアクセスしているか？
 - ✅ manifest.json が200で返ってくるか？
   ```bash
-  curl https://naruto-shelter-map.pages.dev/manifest.json
+  curl https://naruto-hinan.com/manifest.json
   ```
 - ✅ manifest.json にアイコンが定義されているか？
 - ✅ Service Workerが登録されているか？

--- a/.docs/sop/deployment.md
+++ b/.docs/sop/deployment.md
@@ -7,7 +7,7 @@
 ## 概要
 
 - **ホスティング:** Cloudflare Pages
-- **本番 URL:** https://naruto-shelter-map.pages.dev（例）
+- **本番 URL:** https://naruto-hinan.com
 - **デプロイ方式:** GitHub の **main** ブランチへの push（またはマージ）に連動した **自動ビルド・デプロイ**
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 鳴門市避難所マップ (Naruto Shelter Map)
+# 鳴門避難マップ (Naruto Hinan Map)
 
 [![Deploy to Cloudflare Pages](https://img.shields.io/badge/deploy-cloudflare-orange)](https://pages.cloudflare.com)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
@@ -17,9 +17,9 @@
 
 オフライン環境でも動作する PWA 技術により、いつでも避難所情報を確認できます。
 
-> **デモサイト:** https://naruto-shelter-map.pages.dev
+> **サイト:** https://naruto-hinan.com
 >
-> [![デモサイトを開く](https://img.shields.io/badge/🌐_デモサイト-Open-blue?style=for-the-badge)](https://naruto-shelter-map.pages.dev)
+> [![サイトを開く](https://img.shields.io/badge/🌐_サイトを開く-Open-blue?style=for-the-badge)](https://naruto-hinan.com)
 
 ---
 
@@ -176,7 +176,7 @@ http://localhost:5173
 
 本プロジェクトは **Cloudflare Pages** にデプロイされています。
 
-- **本番 URL:** https://naruto-shelter-map.pages.dev
+- **本番 URL:** https://naruto-hinan.com
 - **ビルド:** `pnpm build` で生成された静的アウトプットを Cloudflare Pages が配信
 - **ブランチ:** `main` へのマージで自動デプロイ（GitHub Actions 連携時）
 


### PR DESCRIPTION
## Summary
- `naruto-shelter-map.pages.dev` → `naruto-hinan.com` に全ドキュメントのURLを更新
- README.mdのプロジェクト名を「鳴門避難マップ」に変更

## 変更ファイル
- `README.md` — サイトURL・プロジェクト名・本番URL
- `.docs/sop/deployment.md` — 本番URL
- `.docs/cloudflare-pages-setup.md` — 全URLリファレンス（4箇所）

## 備考
- ソースコードは全て相対パスのため変更不要
- PWA manifest / Service Worker も相対パスで変更不要

Closes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)