### PR TITLE
refactor: extract useHomePageState hook and UI components

### DIFF
--- a/src/components/error/RefreshErrorToast.tsx
+++ b/src/components/error/RefreshErrorToast.tsx
@@ -1,0 +1,45 @@
+interface RefreshErrorToastProps {
+  error: Error;
+  onClose: () => void;
+}
+
+export function RefreshErrorToast({
+  error,
+  onClose,
+}: RefreshErrorToastProps): React.JSX.Element {
+  const message =
+    error.message.includes('fetch') || error.message.includes('Network')
+      ? 'オフラインのため更新できません'
+      : error.message;
+
+  return (
+    <div
+      role="alert"
+      aria-live="polite"
+      className="fixed bottom-4 left-4 right-4 z-50 flex items-center justify-between gap-3 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 shadow-lg sm:left-auto sm:right-4 sm:max-w-sm"
+    >
+      <p className="text-sm text-amber-900">{message}</p>
+      <button
+        type="button"
+        onClick={onClose}
+        className="shrink-0 rounded p-1 text-amber-700 hover:bg-amber-100 focus:outline-none focus:ring-2 focus:ring-amber-400"
+        aria-label="閉じる"
+      >
+        <svg
+          className="h-5 w-5"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M6 18L18 6M6 6l12 12"
+          />
+        </svg>
+      </button>
+    </div>
+  );
+}

--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -4,7 +4,6 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import MapGL, {
   Marker,
   NavigationControl,
-  Popup,
   useMap,
   type ViewStateChangeEvent,
 } from 'react-map-gl/maplibre';
@@ -13,12 +12,12 @@ import type {
   GeolocationError,
   GeolocationState,
 } from '@/hooks/useGeolocation';
-import { generateNavigationURL } from '@/lib/navigation';
 import { MAP_STYLES } from '@/types/map';
 import type { ShelterFeature } from '@/types/shelter';
 import { CurrentLocationButton } from './CurrentLocationButton';
 import { FilterButton } from './FilterButton';
 import { ShelterPinMarker } from './ShelterPinMarker';
+import { ShelterPopup } from './ShelterPopup';
 import 'maplibre-gl/dist/maplibre-gl.css';
 
 interface MapProps {
@@ -287,98 +286,11 @@ export function ShelterMap({
         )}
 
         {selectedShelter && (
-          <Popup
-            key={selectedShelter.properties.id}
-            longitude={selectedShelter.geometry.coordinates[0]}
-            latitude={selectedShelter.geometry.coordinates[1]}
-            anchor="bottom"
+          <ShelterPopup
+            shelter={selectedShelter}
             onClose={handleClosePopup}
-            closeButton={true}
-            closeOnClick={false}
-            className="shelter-popup"
-          >
-            <div className="p-4">
-              <h3 className="mb-2 font-bold text-gray-900">
-                {selectedShelter.properties.name}
-              </h3>
-              <div className="space-y-1 text-sm text-gray-700 mb-3">
-                <p>
-                  <span className="font-semibold">種別:</span>{' '}
-                  {selectedShelter.properties.type}
-                </p>
-                <p>
-                  <span className="font-semibold">住所:</span>{' '}
-                  {selectedShelter.properties.address}
-                </p>
-                <p>
-                  <span className="font-semibold">災害種別:</span>{' '}
-                  {selectedShelter.properties.disasterTypes.join('・')}
-                </p>
-                {selectedShelter.properties.capacity && (
-                  <p>
-                    <span className="font-semibold">収容人数:</span>{' '}
-                    {selectedShelter.properties.capacity}人
-                  </p>
-                )}
-              </div>
-              <div className="flex flex-col gap-2">
-                <button
-                  type="button"
-                  onClick={() => {
-                    onShowDetail?.(selectedShelter);
-                  }}
-                  className="w-full flex items-center justify-center gap-2 px-3 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2"
-                  aria-label={`${selectedShelter.properties.name}の詳細を見る`}
-                >
-                  <svg
-                    className="h-4 w-4"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                    aria-hidden="true"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                    />
-                  </svg>
-                  <span>詳細を見る</span>
-                </button>
-                <button
-                  type="button"
-                  onClick={() => {
-                    const [lng, lat] = selectedShelter.geometry.coordinates;
-                    const url = generateNavigationURL(
-                      { latitude: lat, longitude: lng },
-                      undefined,
-                      'walking'
-                    );
-                    window.open(url, '_blank', 'noopener,noreferrer');
-                  }}
-                  className="w-full flex items-center justify-center gap-2 px-3 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2"
-                  aria-label={`${selectedShelter.properties.name}への経路案内`}
-                >
-                  <svg
-                    className="h-4 w-4"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                    aria-hidden="true"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l4.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-.553-.894L15 4m0 13V4m0 0L9 7"
-                    />
-                  </svg>
-                  <span>経路案内を開く</span>
-                </button>
-              </div>
-            </div>
-          </Popup>
+            onShowDetail={onShowDetail}
+          />
         )}
       </MapGL>
 

--- a/src/components/map/ShelterPopup.tsx
+++ b/src/components/map/ShelterPopup.tsx
@@ -1,0 +1,105 @@
+import { Popup } from 'react-map-gl/maplibre';
+import { generateNavigationURL } from '@/lib/navigation';
+import type { ShelterFeature } from '@/types/shelter';
+
+interface ShelterPopupProps {
+  shelter: ShelterFeature;
+  onClose: () => void;
+  onShowDetail?: ((shelter: ShelterFeature) => void) | undefined;
+}
+
+export function ShelterPopup({
+  shelter,
+  onClose,
+  onShowDetail,
+}: ShelterPopupProps): React.JSX.Element {
+  const [lng, lat] = shelter.geometry.coordinates;
+  const { name, type, address, disasterTypes, capacity } = shelter.properties;
+
+  return (
+    <Popup
+      key={shelter.properties.id}
+      longitude={lng}
+      latitude={lat}
+      anchor="bottom"
+      onClose={onClose}
+      closeButton={true}
+      closeOnClick={false}
+      className="shelter-popup"
+    >
+      <div className="p-4">
+        <h3 className="mb-2 font-bold text-gray-900">{name}</h3>
+        <div className="space-y-1 text-sm text-gray-700 mb-3">
+          <p>
+            <span className="font-semibold">種別:</span> {type}
+          </p>
+          <p>
+            <span className="font-semibold">住所:</span> {address}
+          </p>
+          <p>
+            <span className="font-semibold">災害種別:</span>{' '}
+            {disasterTypes.join('・')}
+          </p>
+          {capacity && (
+            <p>
+              <span className="font-semibold">収容人数:</span> {capacity}人
+            </p>
+          )}
+        </div>
+        <div className="flex flex-col gap-2">
+          <button
+            type="button"
+            onClick={() => onShowDetail?.(shelter)}
+            className="w-full flex items-center justify-center gap-2 px-3 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2"
+            aria-label={`${name}の詳細を見る`}
+          >
+            <svg
+              className="h-4 w-4"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+              />
+            </svg>
+            <span>詳細を見る</span>
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              const url = generateNavigationURL(
+                { latitude: lat, longitude: lng },
+                undefined,
+                'walking'
+              );
+              window.open(url, '_blank', 'noopener,noreferrer');
+            }}
+            className="w-full flex items-center justify-center gap-2 px-3 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2"
+            aria-label={`${name}への経路案内`}
+          >
+            <svg
+              className="h-4 w-4"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l4.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-.553-.894L15 4m0 13V4m0 0L9 7"
+              />
+            </svg>
+            <span>経路案内を開く</span>
+          </button>
+        </div>
+      </div>
+    </Popup>
+  );
+}

--- a/src/hooks/useHomePageState.ts
+++ b/src/hooks/useHomePageState.ts
@@ -1,0 +1,214 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useLocation, useRoute } from 'wouter';
+import type { SortMode } from '@/components/shelter/SortToggle';
+import { useFavorites } from '@/hooks/useFavorites';
+import { useFilteredShelters } from '@/hooks/useFilteredShelters';
+import { useGeolocation } from '@/hooks/useGeolocation';
+import { useShelters } from '@/hooks/useShelters';
+import { calculateDistance, toCoordinates } from '@/lib/geo';
+import type { ShelterFeature } from '@/types/shelter';
+
+interface ShelterWithDistance {
+  shelter: ShelterFeature;
+  distance: number | null;
+}
+
+export interface HomePageState {
+  /** データ */
+  filteredShelters: ShelterFeature[];
+  allSheltersCount: number;
+  listShelters: ShelterWithDistance[];
+  isLoading: boolean;
+  error: Error | null;
+  retry: () => void;
+
+  /** リフレッシュ */
+  refresh: () => Promise<void>;
+  isRefreshing: boolean;
+  refreshError: Error | null;
+  clearRefreshError: () => void;
+
+  /** 選択・詳細 */
+  selectedShelterId: string | null;
+  setSelectedShelterId: (id: string | null) => void;
+  detailModalShelter: ShelterFeature | null;
+  openDetail: (shelter: ShelterFeature) => void;
+  closeDetail: () => void;
+
+  /** 位置情報 */
+  position: ReturnType<typeof useGeolocation>['position'];
+  geolocationState: ReturnType<typeof useGeolocation>['state'];
+  geolocationError: ReturnType<typeof useGeolocation>['error'];
+  getCurrentPosition: () => void;
+
+  /** お気に入り */
+  favorites: Set<string>;
+  toggleFavorite: (id: string) => void;
+
+  /** ソート・フィルタ */
+  sortMode: SortMode;
+  setSortMode: (mode: SortMode) => void;
+  listFilter: 'all' | 'favorites' | 'chat';
+  setListFilter: (filter: 'all' | 'favorites' | 'chat') => void;
+
+  /** チャット */
+  chatModalOpen: boolean;
+  setChatModalOpen: (open: boolean) => void;
+
+  /** 利用規約 */
+  showTerms: boolean;
+  openTerms: () => void;
+  closeTerms: () => void;
+}
+
+export function useHomePageState(): HomePageState {
+  const [, setLocation] = useLocation();
+  const [match, params] = useRoute('/shelter/:id');
+  const shelterIdFromUrl = match ? (params.id ?? null) : null;
+  const [termsMatch] = useRoute('/terms');
+  const showTerms = !!termsMatch;
+
+  const {
+    data,
+    isLoading,
+    error,
+    retry,
+    refresh,
+    isRefreshing,
+    refreshError,
+    clearRefreshError,
+  } = useShelters();
+  const {
+    position,
+    state: geolocationState,
+    error: geolocationError,
+    getCurrentPosition,
+  } = useGeolocation();
+  const { favorites, toggleFavorite } = useFavorites();
+
+  const [selectedShelterIdState, setSelectedShelterIdState] = useState<
+    string | null
+  >(null);
+  const [sortMode, setSortMode] = useState<SortMode>('name');
+  const [listFilter, setListFilter] = useState<'all' | 'favorites' | 'chat'>(
+    'all'
+  );
+  const [chatModalOpen, setChatModalOpen] = useState(false);
+
+  const selectedShelterId = shelterIdFromUrl ?? selectedShelterIdState;
+  const setSelectedShelterId = useCallback((id: string | null) => {
+    setSelectedShelterIdState(id);
+  }, []);
+
+  const detailModalShelter = useMemo(() => {
+    if (!shelterIdFromUrl || !data?.features) return null;
+    return (
+      data.features.find((f) => f.properties.id === shelterIdFromUrl) ?? null
+    );
+  }, [shelterIdFromUrl, data]);
+
+  const openDetail = useCallback(
+    (shelter: ShelterFeature) => {
+      setLocation(`/shelter/${shelter.properties.id}`);
+    },
+    [setLocation]
+  );
+  const closeDetail = useCallback(() => {
+    if (shelterIdFromUrl) {
+      setSelectedShelterIdState(shelterIdFromUrl);
+    }
+    setLocation('/');
+  }, [setLocation, shelterIdFromUrl]);
+
+  const openTerms = useCallback(() => {
+    setLocation('/terms');
+  }, [setLocation]);
+  const closeTerms = useCallback(() => {
+    setLocation('/');
+  }, [setLocation]);
+
+  // 存在しない id の場合はトップへリダイレクト
+  useEffect(() => {
+    if (
+      shelterIdFromUrl &&
+      data?.features &&
+      !data.features.some((f) => f.properties.id === shelterIdFromUrl)
+    ) {
+      setLocation('/');
+    }
+  }, [shelterIdFromUrl, data?.features, setLocation]);
+
+  const allShelters = data?.features ?? [];
+  const filteredShelters = useFilteredShelters(allShelters);
+
+  const sortedShelters = useMemo(() => {
+    const sheltersWithDistance = filteredShelters.map((shelter) => ({
+      shelter,
+      distance:
+        position && shelter.geometry.coordinates
+          ? calculateDistance(
+              position,
+              toCoordinates(shelter.geometry.coordinates)
+            )
+          : null,
+    }));
+
+    if (sortMode === 'distance' && position) {
+      return sheltersWithDistance
+        .filter((item) => item.distance !== null)
+        .sort((a, b) => {
+          if (a.distance === null || b.distance === null) return 0;
+          return a.distance - b.distance;
+        });
+    }
+
+    return sheltersWithDistance.sort((a, b) =>
+      a.shelter.properties.name.localeCompare(
+        b.shelter.properties.name,
+        'ja-JP'
+      )
+    );
+  }, [filteredShelters, sortMode, position]);
+
+  const listShelters = useMemo(() => {
+    if (listFilter === 'favorites') {
+      return sortedShelters.filter((item) =>
+        favorites.has(item.shelter.properties.id)
+      );
+    }
+    return sortedShelters;
+  }, [sortedShelters, listFilter, favorites]);
+
+  return {
+    filteredShelters,
+    allSheltersCount: allShelters.length,
+    listShelters,
+    isLoading,
+    error,
+    retry,
+    refresh,
+    isRefreshing,
+    refreshError,
+    clearRefreshError,
+    selectedShelterId,
+    setSelectedShelterId,
+    detailModalShelter,
+    openDetail,
+    closeDetail,
+    position,
+    geolocationState,
+    geolocationError,
+    getCurrentPosition,
+    favorites,
+    toggleFavorite,
+    sortMode,
+    setSortMode,
+    setListFilter,
+    listFilter,
+    chatModalOpen,
+    setChatModalOpen,
+    showTerms,
+    openTerms,
+    closeTerms,
+  };
+}


### PR DESCRIPTION
## Summary
- App.tsx の状態管理ロジックを `useHomePageState` カスタムフックに抽出 (333 → 185行)
- Map.tsx のポップアップ UI を `ShelterPopup` コンポーネントに抽出 (395 → 310行)
- App.tsx のエラートーストを `RefreshErrorToast` コンポーネントに抽出

## Test plan
- [ ] lint / type-check / build パス確認済み
- [ ] マーカークリック → ポップアップ表示 → 詳細・経路案内の動作確認
- [ ] データ更新エラー時のトースト表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)