### PR TITLE
fix(chat): iPhoneホームインジケーター対応

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" href="/icon.svg" type="image/svg+xml" />
     <link rel="icon" href="/favicon.ico" sizes="32x32" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover" />
     <meta name="theme-color" content="#3b82f6" />
     <meta name="description" content="徳島県鳴門市の避難所を地図上で確認できるウェブアプリ" />
     <link rel="manifest" href="/manifest.json" />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -108,7 +108,7 @@ function HomePageContent({ mainContentId }: { mainContentId: string }) {
             />
           </Suspense>
         </main>
-        <div className="absolute bottom-34 right-4 z-10">
+        <div className="absolute bottom-[calc(8.5rem+env(safe-area-inset-bottom))] right-4 z-10">
           <ChatFab onClick={() => setChatModalOpen(true)} />
         </div>
       </div>

--- a/src/components/chat/ChatModal.tsx
+++ b/src/components/chat/ChatModal.tsx
@@ -44,7 +44,7 @@ export function ChatModal({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex flex-col bg-white"
+      className="fixed inset-0 z-50 flex flex-col bg-white pb-[env(safe-area-inset-bottom)]"
       role="dialog"
       aria-modal="true"
       aria-labelledby={titleId}


### PR DESCRIPTION
## Summary
- `viewport-fit=cover` を追加して `env(safe-area-inset-bottom)` を有効化
- ChatModal に bottom padding を追加し、ホームインジケーター分の余白を確保
- ChatFab の位置を safe-area 対応に調整

## Test plan
- [ ] iPhone実機でチャットモーダルを開き、入力欄がホームインジケーターに隠れないことを確認
- [ ] iPhone実機でChatFabボタンがホームインジケーターと重ならないことを確認
- [ ] デスクトップ表示に影響がないことを確認

Closes #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)