### PR TITLE
chore: remove legacy Turbopack placeholder file

### DIFF
--- a/empty.js
+++ b/empty.js
@@ -1,3 +1,0 @@
-// Empty module for Turbopack resolve aliases
-// Used to disable Node.js built-in modules on client side
-export default {};


### PR DESCRIPTION
## Summary
- Next.js → Vite 移行時に残っていた `empty.js`（Turbopack resolve alias 用）を削除
- どこからも参照されておらず完全に不要なファイル

## Test plan
- [ ] `pnpm build` が正常に完了すること
- [ ] `pnpm lint` でエラーがないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)