### PR TITLE
feat(ui): add shadcn/ui primitive components (Phase 1)

### DIFF
--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -1,4 +1,6 @@
 import { type FormEvent, useCallback, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 
 interface ChatInputProps {
   onSubmit: (query: string) => void;
@@ -30,24 +32,24 @@ export function ChatInput({
       className="flex gap-2 border-t border-gray-200 bg-white p-2"
       aria-label="避難所について質問"
     >
-      <input
+      <Input
         type="text"
         value={value}
         onChange={(e) => setValue(e.target.value)}
         placeholder={placeholder}
         disabled={disabled}
-        className="min-w-0 flex-1 rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 placeholder-gray-500 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-400 disabled:bg-gray-100 disabled:text-gray-500"
+        className="min-w-0 flex-1"
         aria-label="質問を入力"
         autoComplete="off"
       />
-      <button
+      <Button
         type="submit"
         disabled={disabled || value.trim().length === 0}
-        className="shrink-0 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2 disabled:opacity-50"
+        size="sm"
         aria-label="送信"
       >
         送信
-      </button>
+      </Button>
     </form>
   );
 }

--- a/src/components/error/NetworkError.tsx
+++ b/src/components/error/NetworkError.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement } from 'react';
+import { Button } from '@/components/ui/button';
 
 interface NetworkErrorProps {
   message?: string;
@@ -51,13 +52,9 @@ export function NetworkError({
 
         {/* リトライボタン */}
         {onRetry && (
-          <button
-            type="button"
-            onClick={onRetry}
-            className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-6 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2 transition-colors"
-          >
+          <Button onClick={onRetry}>
             <svg
-              className="h-4 w-4"
+              className="size-4"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -71,7 +68,7 @@ export function NetworkError({
               />
             </svg>
             再試行
-          </button>
+          </Button>
         )}
       </div>
     </div>

--- a/src/components/filter/DisasterTypeFilter.tsx
+++ b/src/components/filter/DisasterTypeFilter.tsx
@@ -1,4 +1,6 @@
 import type { ReactElement } from 'react';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 import { useFilter } from '@/contexts/FilterContext';
 import type { DisasterType } from '@/types/shelter';
 
@@ -136,14 +138,14 @@ export function DisasterTypeFilter(): ReactElement {
       <div className="mb-3 flex items-center justify-between">
         <h3 className="text-sm font-semibold text-gray-900">災害種別</h3>
         {selectedDisasters.length > 0 && (
-          <button
-            type="button"
+          <Button
+            variant="link"
+            size="xs"
             onClick={clearFilters}
-            className="text-xs text-blue-600 hover:text-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
             aria-label="フィルタをクリア"
           >
             クリア
-          </button>
+          </Button>
         )}
       </div>
 
@@ -154,25 +156,15 @@ export function DisasterTypeFilter(): ReactElement {
           return (
             <label
               key={disaster}
+              htmlFor={`filter-${disaster}`}
               className={`flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 transition-colors ${
                 isSelected ? 'bg-blue-50 hover:bg-blue-100' : 'hover:bg-gray-50'
               }`}
             >
-              <input
-                type="checkbox"
+              <Checkbox
+                id={`filter-${disaster}`}
                 checked={isSelected}
-                onChange={() => toggleDisaster(disaster)}
-                className="h-4 w-4 cursor-pointer appearance-none rounded border-2 bg-white focus:ring-2 focus:ring-blue-500 focus:ring-offset-0"
-                style={{
-                  backgroundColor: isSelected ? '#2563eb' : 'white',
-                  borderColor: isSelected ? '#2563eb' : '#d1d5db',
-                  backgroundImage: isSelected
-                    ? "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath fill='white' d='M13.854 3.646a.5.5 0 0 1 0 .708l-7 7a.5.5 0 0 1-.708 0l-3.5-3.5a.5.5 0 1 1 .708-.708L6.5 10.293l6.646-6.647a.5.5 0 0 1 .708 0z'/%3E%3C/svg%3E\")"
-                    : 'none',
-                  backgroundSize: 'contain',
-                  backgroundPosition: 'center',
-                  backgroundRepeat: 'no-repeat',
-                }}
+                onCheckedChange={() => toggleDisaster(disaster)}
                 aria-label={`${disaster}で絞り込む`}
               />
               <IconComponent

--- a/src/components/layout/DesktopSidebar.tsx
+++ b/src/components/layout/DesktopSidebar.tsx
@@ -2,6 +2,7 @@ import { ChatPanel } from '@/components/chat/ChatPanel';
 import { DisasterTypeFilter } from '@/components/filter/DisasterTypeFilter';
 import { ShelterList } from '@/components/shelter/ShelterList';
 import { type SortMode, SortToggle } from '@/components/shelter/SortToggle';
+import { Button } from '@/components/ui/button';
 import type { Coordinates } from '@/lib/geo';
 import type { ShelterFeature } from '@/types/shelter';
 
@@ -67,22 +68,22 @@ export function DesktopSidebar({
             鳴門避難マップ
           </h1>
           <div className="flex items-center gap-1.5">
-            <button
-              type="button"
+            <Button
+              variant="outline"
+              size="icon-sm"
               onClick={() => void onRefresh()}
               disabled={isRefreshing}
-              className="flex items-center justify-center rounded-lg border border-gray-300 bg-white p-1.5 text-gray-700 transition-colors hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2 disabled:opacity-60"
               aria-label="避難所データを最新に更新"
               title="通信して最新の避難所データを取得します"
             >
               {isRefreshing ? (
                 <span
-                  className="h-4 w-4 animate-spin rounded-full border-2 border-gray-300 border-t-blue-600"
+                  className="size-4 animate-spin rounded-full border-2 border-gray-300 border-t-blue-600"
                   aria-hidden
                 />
               ) : (
                 <svg
-                  className="h-4 w-4"
+                  className="size-4"
                   fill="none"
                   stroke="currentColor"
                   viewBox="0 0 24 24"
@@ -96,16 +97,16 @@ export function DesktopSidebar({
                   />
                 </svg>
               )}
-            </button>
-            <button
-              type="button"
+            </Button>
+            <Button
+              variant="outline"
+              size="icon-sm"
               onClick={onShowTerms}
-              className="flex items-center justify-center rounded-lg border border-gray-300 bg-white p-1.5 text-gray-700 transition-colors hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2"
               aria-label="利用規約を表示"
               title="利用規約"
             >
               <svg
-                className="h-4 w-4"
+                className="size-4"
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
@@ -118,7 +119,7 @@ export function DesktopSidebar({
                   d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
                 />
               </svg>
-            </button>
+            </Button>
           </div>
         </div>
         <p className="text-sm text-gray-700">

--- a/src/components/map/FilterButton.tsx
+++ b/src/components/map/FilterButton.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { DisasterTypeFilter } from '@/components/filter/DisasterTypeFilter';
+import { Button } from '@/components/ui/button';
 import { useFilter } from '@/contexts/FilterContext';
 
 export function FilterButton() {
@@ -10,14 +11,10 @@ export function FilterButton() {
   return (
     <>
       {/* フィルタボタン */}
-      <button
-        type="button"
+      <Button
+        variant="outline"
         onClick={() => setIsOpen(!isOpen)}
-        className={`
-          flex items-center gap-2 rounded-full bg-white px-4 py-2.5 shadow-lg
-          transition-all hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2
-          ${hasActiveFilters ? 'border-2 border-blue-500' : 'border border-gray-200'}
-        `}
+        className={`rounded-full bg-white shadow-lg hover:shadow-xl ${hasActiveFilters ? 'border-2 border-blue-500' : ''}`}
         aria-label="フィルタ"
         aria-expanded={isOpen}
       >
@@ -27,7 +24,7 @@ export function FilterButton() {
             {selectedDisasters.length}
           </span>
         )}
-      </button>
+      </Button>
 
       {/* フィルタドロワー */}
       {isOpen && (

--- a/src/components/pwa/InstallPrompt.tsx
+++ b/src/components/pwa/InstallPrompt.tsx
@@ -1,5 +1,6 @@
 import type { ReactElement } from 'react';
 import { useState } from 'react';
+import { Button } from '@/components/ui/button';
 import { usePWAInstall } from '@/hooks/usePWAInstall';
 
 /**
@@ -54,30 +55,23 @@ export function InstallPrompt(): ReactElement | null {
             ホーム画面に追加して、オフラインでも避難所情報を確認できます。
           </p>
           <div className="mt-3 flex gap-2">
-            <button
-              type="button"
-              onClick={handleInstall}
-              className="rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-            >
+            <Button size="sm" onClick={handleInstall}>
               インストール
-            </button>
-            <button
-              type="button"
-              onClick={handleDismiss}
-              className="rounded-md bg-gray-100 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2"
-            >
+            </Button>
+            <Button variant="secondary" size="sm" onClick={handleDismiss}>
               後で
-            </button>
+            </Button>
           </div>
         </div>
-        <button
-          type="button"
+        <Button
+          variant="ghost"
+          size="icon-sm"
           onClick={handleDismiss}
-          className="flex-shrink-0 text-gray-400 hover:text-gray-500"
+          className="shrink-0"
           aria-label="閉じる"
         >
           <svg
-            className="h-5 w-5"
+            className="size-5"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
@@ -90,7 +84,7 @@ export function InstallPrompt(): ReactElement | null {
               d="M6 18L18 6M6 6l12 12"
             />
           </svg>
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/src/components/pwa/UpdateNotification.tsx
+++ b/src/components/pwa/UpdateNotification.tsx
@@ -1,5 +1,6 @@
 import type { ReactElement } from 'react';
 import { useState } from 'react';
+import { Button } from '@/components/ui/button';
 import { useServiceWorkerUpdate } from '@/hooks/useServiceWorkerUpdate';
 
 /**
@@ -59,33 +60,29 @@ export function UpdateNotification(): ReactElement | null {
             最新バージョンを利用するには、ページを更新してください。
           </p>
           <div className="mt-3 flex gap-2">
-            <button
-              type="button"
-              onClick={handleUpdate}
-              disabled={isUpdating}
-              className="rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
-            >
+            <Button size="sm" onClick={handleUpdate} disabled={isUpdating}>
               {isUpdating ? '更新中...' : '更新する'}
-            </button>
-            <button
-              type="button"
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
               onClick={handleDismiss}
               disabled={isUpdating}
-              className="rounded-md bg-gray-100 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               後で
-            </button>
+            </Button>
           </div>
         </div>
-        <button
-          type="button"
+        <Button
+          variant="ghost"
+          size="icon-sm"
           onClick={handleDismiss}
           disabled={isUpdating}
-          className="flex-shrink-0 text-gray-400 hover:text-gray-500 disabled:opacity-50 disabled:cursor-not-allowed"
+          className="shrink-0"
           aria-label="閉じる"
         >
           <svg
-            className="h-5 w-5"
+            className="size-5"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
@@ -98,7 +95,7 @@ export function UpdateNotification(): ReactElement | null {
               d="M6 18L18 6M6 6l12 12"
             />
           </svg>
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/src/components/shelter/ShelterCard.tsx
+++ b/src/components/shelter/ShelterCard.tsx
@@ -1,5 +1,6 @@
 import { clsx } from 'clsx';
 import { memo, useState } from 'react';
+import { Button } from '@/components/ui/button';
 import type { Coordinates } from '@/lib/geo';
 import {
   calculateBearing,
@@ -213,8 +214,9 @@ function ShelterCardComponent({
         {/* アクションボタン */}
         <div className="flex items-center gap-2 pt-2 border-t border-gray-200">
           {/* 詳細を見るボタン（onShowDetail ありなら地図側でモーダルを開く） */}
-          <button
-            type="button"
+          <Button
+            variant="secondary"
+            size="sm"
             onClick={(e) => {
               e.stopPropagation();
               if (onShowDetail) {
@@ -223,11 +225,10 @@ function ShelterCardComponent({
                 setIsDetailOpen(true);
               }
             }}
-            className="flex items-center justify-center gap-1.5 px-3 py-1.5 text-sm font-medium text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200 transition-colors focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2"
             aria-label={`${name}の詳細を見る`}
           >
             <svg
-              className="h-4 w-4"
+              className="size-4"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -241,13 +242,15 @@ function ShelterCardComponent({
               />
             </svg>
             <span className="truncate">詳細</span>
-          </button>
+          </Button>
 
           {/* 経路案内ボタン（距離がある場合のみ） */}
           {distance !== null && distance !== undefined && (
             <>
-              <button
-                type="button"
+              <Button
+                variant="outline"
+                size="sm"
+                className="flex-1"
                 onClick={(e) => {
                   e.stopPropagation();
                   const [lng, lat] = shelter.geometry.coordinates;
@@ -258,11 +261,10 @@ function ShelterCardComponent({
                   );
                   window.open(url, '_blank', 'noopener,noreferrer');
                 }}
-                className="flex-1 flex items-center justify-center gap-1.5 px-3 py-1.5 text-sm font-medium text-blue-600 bg-blue-50 rounded-md hover:bg-blue-100 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2"
                 aria-label={`${name}への経路案内`}
               >
                 <svg
-                  className="h-4 w-4"
+                  className="size-4"
                   fill="none"
                   stroke="currentColor"
                   viewBox="0 0 24 24"
@@ -276,7 +278,7 @@ function ShelterCardComponent({
                   />
                 </svg>
                 <span className="truncate">経路案内</span>
-              </button>
+              </Button>
               <div className="flex items-center gap-2 text-sm text-gray-700">
                 <span
                   className="whitespace-nowrap"

--- a/src/components/shelter/ShelterDetailModal.tsx
+++ b/src/components/shelter/ShelterDetailModal.tsx
@@ -1,5 +1,7 @@
 import { clsx } from 'clsx';
 import { useEffect, useId, useRef } from 'react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
 import type { Coordinates } from '@/lib/geo';
 import { formatDistance } from '@/lib/geo';
@@ -143,15 +145,16 @@ export function ShelterDetailModal({
                 )}
               </button>
             )}
-            <button
+            <Button
               ref={closeButtonRef}
-              type="button"
+              variant="ghost"
+              size="icon"
               onClick={onClose}
-              className="rounded-full p-2 transition-colors hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2"
+              className="rounded-full"
               aria-label="閉じる"
             >
               <svg
-                className="h-6 w-6"
+                className="size-6"
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
@@ -164,7 +167,7 @@ export function ShelterDetailModal({
                   d="M6 18L18 6M6 6l12 12"
                 />
               </svg>
-            </button>
+            </Button>
           </div>
         </div>
 
@@ -276,12 +279,13 @@ export function ShelterDetailModal({
             </h3>
             <div className="flex flex-wrap gap-2">
               {disasterTypes.map((disasterType) => (
-                <span
+                <Badge
                   key={disasterType}
-                  className="inline-flex items-center rounded-full bg-orange-50 px-3 py-1 text-xs font-medium text-orange-900 border border-orange-200"
+                  variant="outline"
+                  className="bg-orange-50 text-orange-900 border-orange-200"
                 >
                   {disasterType}
-                </span>
+                </Badge>
               ))}
             </div>
           </section>
@@ -371,8 +375,9 @@ export function ShelterDetailModal({
 
         {/* フッター: アクションボタン */}
         <div className="sticky bottom-0 border-t border-gray-200 bg-white p-4">
-          <button
-            type="button"
+          <Button
+            className="w-full py-3"
+            size="lg"
             onClick={() => {
               const url = generateNavigationURL(
                 { latitude: lat, longitude: lng },
@@ -381,10 +386,9 @@ export function ShelterDetailModal({
               );
               window.open(url, '_blank', 'noopener,noreferrer');
             }}
-            className="w-full flex items-center justify-center gap-2 rounded-lg bg-blue-600 px-4 py-3 text-sm font-semibold text-white shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2 transition-colors"
           >
             <svg
-              className="h-5 w-5"
+              className="size-5"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -398,7 +402,7 @@ export function ShelterDetailModal({
               />
             </svg>
             経路案内を表示
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,48 @@
+import { cva, type VariantProps } from 'class-variance-authority';
+import { Slot } from 'radix-ui';
+import type * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+const badgeVariants = cva(
+  'inline-flex items-center justify-center rounded-full border border-transparent px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden',
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground [a&]:hover:bg-primary/90',
+        secondary:
+          'bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90',
+        destructive:
+          'bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
+        outline:
+          'border-border text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground',
+        ghost: '[a&]:hover:bg-accent [a&]:hover:text-accent-foreground',
+        link: 'text-primary underline-offset-4 [a&]:hover:underline',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  }
+);
+
+function Badge({
+  className,
+  variant = 'default',
+  asChild = false,
+  ...props
+}: React.ComponentProps<'span'> &
+  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot.Root : 'span';
+
+  return (
+    <Comp
+      data-slot="badge"
+      data-variant={variant}
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+export { Badge, badgeVariants };

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,64 @@
+import { cva, type VariantProps } from 'class-variance-authority';
+import { Slot } from 'radix-ui';
+import type * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        destructive:
+          'bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
+        outline:
+          'border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50',
+        secondary:
+          'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        ghost:
+          'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
+        link: 'text-primary underline-offset-4 hover:underline',
+      },
+      size: {
+        default: 'h-9 px-4 py-2 has-[>svg]:px-3',
+        xs: "h-6 gap-1 rounded-md px-2 text-xs has-[>svg]:px-1.5 [&_svg:not([class*='size-'])]:size-3",
+        sm: 'h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5',
+        lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
+        icon: 'size-9',
+        'icon-xs': "size-6 rounded-md [&_svg:not([class*='size-'])]:size-3",
+        'icon-sm': 'size-8',
+        'icon-lg': 'size-10',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  }
+);
+
+function Button({
+  className,
+  variant = 'default',
+  size = 'default',
+  asChild = false,
+  ...props
+}: React.ComponentProps<'button'> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean;
+  }) {
+  const Comp = asChild ? Slot.Root : 'button';
+
+  return (
+    <Comp
+      data-slot="button"
+      data-variant={variant}
+      data-size={size}
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  );
+}
+
+export { Button, buttonVariants };

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,92 @@
+import type * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+function Card({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        'bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        '@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-2 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn('leading-none font-semibold', className)}
+      {...props}
+    />
+  );
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn('text-muted-foreground text-sm', className)}
+      {...props}
+    />
+  );
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        'col-start-2 row-span-2 row-start-1 self-start justify-self-end',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn('px-6', className)}
+      {...props}
+    />
+  );
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn('flex items-center px-6 [.border-t]:pt-6', className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+};

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,0 +1,30 @@
+import { CheckIcon } from 'lucide-react';
+import { Checkbox as CheckboxPrimitive } from 'radix-ui';
+import type * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+function Checkbox({
+  className,
+  ...props
+}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        'peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
+        className
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="grid place-content-center text-current transition-none"
+      >
+        <CheckIcon className="size-3.5" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  );
+}
+
+export { Checkbox };

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,21 @@
+import type * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
+  return (
+    <input
+      type={type}
+      data-slot="input"
+      className={cn(
+        'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
+        'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Input };

--- a/src/globals.css
+++ b/src/globals.css
@@ -2,6 +2,8 @@
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
 
+@custom-variant dark (&:is(.dark *));
+
 @theme {
   /* カスタムカラーパレット（避難所マップ用） */
   --color-primary-500: oklch(0.55 0.15 250);
@@ -121,8 +123,8 @@
   --card-foreground: oklch(0.145 0 0);
   --popover: oklch(1 0 0);
   --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.5 0.18 250);
+  --primary-foreground: oklch(1 0 0);
   --secondary: oklch(0.97 0 0);
   --secondary-foreground: oklch(0.205 0 0);
   --muted: oklch(0.97 0 0);
@@ -132,7 +134,7 @@
   --destructive: oklch(0.577 0.245 27.325);
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
+  --ring: oklch(0.55 0.15 250);
   --chart-1: oklch(0.646 0.222 41.116);
   --chart-2: oklch(0.6 0.118 184.704);
   --chart-3: oklch(0.398 0.07 227.392);


### PR DESCRIPTION
## Summary

Issue #303 Phase 1: shadcn/ui プリミティブ UI コンポーネントの導入

- **Button**: 9 コンポーネントのボタンを shadcn/ui Button に置換（variant/size 統一）
- **Badge**: 災害種別バッジを Badge コンポーネントに置換
- **Input**: チャット入力を Input コンポーネントに置換
- **Checkbox**: 災害種別フィルターを Radix Checkbox に置換（インライン SVG ハック削除）
- **Card**: 将来のカード統一に備えて追加（Phase 1 では未適用）

### 変更対象コンポーネント
- `NetworkError.tsx` — リトライボタン
- `InstallPrompt.tsx` / `UpdateNotification.tsx` — PWA ボタン
- `ChatInput.tsx` — 送信ボタン + テキスト入力
- `ShelterDetailModal.tsx` — 閉じる・ナビゲーションボタン + 災害種別バッジ
- `ShelterCard.tsx` — 詳細・経路案内ボタン
- `DesktopSidebar.tsx` — リフレッシュ・利用規約ボタン
- `FilterButton.tsx` — フィルタートグル
- `DisasterTypeFilter.tsx` — チェックボックス + クリアボタン

### テーマ調整
- `--primary` を blue (`oklch(0.5 0.18 250)`) に変更（プロジェクトのアクションカラーに統一）
- `@custom-variant dark` を再追加（shadcn の `dark:` クラスを安全に無効化）

### バンドルサイズ
- JS: 322KB → 335KB (+13KB)
- CSS: 38KB → 47KB (+9KB)

## Test plan
- [ ] `pnpm lint` エラー 0 件
- [ ] `pnpm type-check` 型エラー 0 件
- [ ] `pnpm build` ビルド成功
- [ ] ブラウザ確認: フィルターチェックボックスの ON/OFF
- [ ] ブラウザ確認: モーダルのボタン表示・クリック
- [ ] ブラウザ確認: PWA バナーのボタン動作
- [ ] モバイル・デスクトップ両方で表示崩れなし

Closes #303 (Phase 1/6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)