### PR TITLE
feat(ui): replace SortToggle with Radix ToggleGroup (Phase 3)

### DIFF
--- a/src/components/shelter/SortToggle.tsx
+++ b/src/components/shelter/SortToggle.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react';
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { cn } from '@/lib/utils';
 
 export type SortMode = 'distance' | 'name';
@@ -10,51 +10,44 @@ interface SortToggleProps {
   className?: string;
 }
 
-export const SortToggle: FC<SortToggleProps> = ({
+export function SortToggle({
   mode,
   onModeChange,
   disabled = false,
   className,
-}) => {
+}: SortToggleProps): React.ReactElement {
   return (
-    <div className={cn('flex gap-2', className)}>
-      {/* 距離順ボタン */}
-      <button
-        type="button"
-        onClick={() => onModeChange('distance')}
-        disabled={disabled}
-        className={cn(
-          'flex flex-1 items-center justify-center gap-1.5 rounded-lg px-3 py-2 text-sm font-medium transition-all',
-          'focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2',
-          mode === 'distance'
-            ? 'bg-blue-500 text-white shadow-md'
-            : 'border border-gray-300 bg-white text-gray-700 hover:bg-gray-50',
-          disabled && 'cursor-not-allowed opacity-50'
-        )}
+    <ToggleGroup
+      type="single"
+      value={mode}
+      onValueChange={(value) => {
+        // Radix ToggleGroup sends "" when deselecting; ignore to keep one always selected
+        if (value) onModeChange(value as SortMode);
+      }}
+      disabled={disabled}
+      className={cn('w-full', className)}
+    >
+      <ToggleGroupItem
+        value="distance"
         aria-label="距離順でソート"
-        aria-current={mode === 'distance' ? 'true' : undefined}
         title={disabled ? '現在地を取得してください' : '距離順でソート'}
+        className="flex flex-1 items-center justify-center gap-1.5 rounded-lg px-3 py-2 data-[state=on]:bg-blue-500 data-[state=on]:text-white data-[state=on]:shadow-md"
       >
-        <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
-          {/* Material Design my_location icon */}
+        <svg
+          className="h-4 w-4"
+          fill="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
           <path d="M12 8c-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4-1.79-4-4-4zm8.94 3A8.994 8.994 0 0013 3.06V1h-2v2.06A8.994 8.994 0 003.06 11H1v2h2.06A8.994 8.994 0 0011 20.94V23h2v-2.06A8.994 8.994 0 0020.94 13H23v-2h-2.06zM12 19c-3.87 0-7-3.13-7-7s3.13-7 7-7 7 3.13 7 7-3.13 7-7 7z" />
         </svg>
         <span>距離順</span>
-      </button>
+      </ToggleGroupItem>
 
-      {/* 名前順ボタン */}
-      <button
-        type="button"
-        onClick={() => onModeChange('name')}
-        className={cn(
-          'flex flex-1 items-center justify-center gap-1.5 rounded-lg px-3 py-2 text-sm font-medium transition-all',
-          'focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2',
-          mode === 'name'
-            ? 'bg-blue-500 text-white shadow-md'
-            : 'border border-gray-300 bg-white text-gray-700 hover:bg-gray-50'
-        )}
+      <ToggleGroupItem
+        value="name"
         aria-label="名前順でソート"
-        aria-current={mode === 'name' ? 'true' : undefined}
+        className="flex flex-1 items-center justify-center gap-1.5 rounded-lg px-3 py-2 data-[state=on]:bg-blue-500 data-[state=on]:text-white data-[state=on]:shadow-md"
       >
         <svg
           className="h-4 w-4"
@@ -62,12 +55,12 @@ export const SortToggle: FC<SortToggleProps> = ({
           stroke="currentColor"
           strokeWidth="2"
           viewBox="0 0 24 24"
+          aria-hidden="true"
         >
-          {/* Sort alphabetically icon */}
           <path d="M3 6h18M7 12h14M11 18h10" />
         </svg>
         <span>名前順</span>
-      </button>
-    </div>
+      </ToggleGroupItem>
+    </ToggleGroup>
   );
-};
+}

--- a/src/components/ui/toggle-group.tsx
+++ b/src/components/ui/toggle-group.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import type { VariantProps } from 'class-variance-authority';
+import { ToggleGroup as ToggleGroupPrimitive } from 'radix-ui';
+import * as React from 'react';
+import { toggleVariants } from '@/components/ui/toggle';
+import { cn } from '@/lib/utils';
+
+const ToggleGroupContext = React.createContext<
+  VariantProps<typeof toggleVariants> & {
+    spacing?: number;
+  }
+>({
+  size: 'default',
+  variant: 'default',
+  spacing: 0,
+});
+
+function ToggleGroup({
+  className,
+  variant,
+  size,
+  spacing = 0,
+  children,
+  ...props
+}: React.ComponentProps<typeof ToggleGroupPrimitive.Root> &
+  VariantProps<typeof toggleVariants> & {
+    spacing?: number;
+  }) {
+  return (
+    <ToggleGroupPrimitive.Root
+      data-slot="toggle-group"
+      data-variant={variant}
+      data-size={size}
+      data-spacing={spacing}
+      style={{ '--gap': spacing } as React.CSSProperties}
+      className={cn(
+        'group/toggle-group flex w-fit items-center gap-[--spacing(var(--gap))] rounded-md data-[spacing=default]:data-[variant=outline]:shadow-xs',
+        className
+      )}
+      {...props}
+    >
+      <ToggleGroupContext.Provider value={{ variant, size, spacing }}>
+        {children}
+      </ToggleGroupContext.Provider>
+    </ToggleGroupPrimitive.Root>
+  );
+}
+
+function ToggleGroupItem({
+  className,
+  children,
+  variant,
+  size,
+  ...props
+}: React.ComponentProps<typeof ToggleGroupPrimitive.Item> &
+  VariantProps<typeof toggleVariants>) {
+  const context = React.useContext(ToggleGroupContext);
+
+  return (
+    <ToggleGroupPrimitive.Item
+      data-slot="toggle-group-item"
+      data-variant={context.variant || variant}
+      data-size={context.size || size}
+      data-spacing={context.spacing}
+      className={cn(
+        toggleVariants({
+          variant: context.variant || variant,
+          size: context.size || size,
+        }),
+        'w-auto min-w-0 shrink-0 px-3 focus:z-10 focus-visible:z-10',
+        'data-[spacing=0]:rounded-none data-[spacing=0]:shadow-none data-[spacing=0]:first:rounded-l-md data-[spacing=0]:last:rounded-r-md data-[spacing=0]:data-[variant=outline]:border-l-0 data-[spacing=0]:data-[variant=outline]:first:border-l',
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </ToggleGroupPrimitive.Item>
+  );
+}
+
+export { ToggleGroup, ToggleGroupItem };

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -1,0 +1,45 @@
+import { cva, type VariantProps } from 'class-variance-authority';
+import { Toggle as TogglePrimitive } from 'radix-ui';
+import type * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+const toggleVariants = cva(
+  "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium hover:bg-muted hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none transition-[color,box-shadow] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive whitespace-nowrap",
+  {
+    variants: {
+      variant: {
+        default: 'bg-transparent',
+        outline:
+          'border border-input bg-transparent shadow-xs hover:bg-accent hover:text-accent-foreground',
+      },
+      size: {
+        default: 'h-9 px-2 min-w-9',
+        sm: 'h-8 px-1.5 min-w-8',
+        lg: 'h-10 px-2.5 min-w-10',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  }
+);
+
+function Toggle({
+  className,
+  variant,
+  size,
+  ...props
+}: React.ComponentProps<typeof TogglePrimitive.Root> &
+  VariantProps<typeof toggleVariants>) {
+  return (
+    <TogglePrimitive.Root
+      data-slot="toggle"
+      className={cn(toggleVariants({ variant, size, className }))}
+      {...props}
+    />
+  );
+}
+
+export { Toggle, toggleVariants };


### PR DESCRIPTION
## Summary

Issue #303 Phase 3: SortToggle を Radix ToggleGroup に置換

- **ToggleGroup**: `type="single"` で距離順/名前順の排他的切り替えを実現
- Radix が `aria-pressed` を自動管理
- `data-[state=on]` でアクティブスタイル (青背景 + 白文字) を維持
- deselect 防止: `onValueChange` で空文字列を無視し、常にどちらかが選択された状態を保持

### バンドルサイズ
- JS: 396KB → 405KB (+9KB: Radix Toggle)
- CSS: 48KB → 50KB (+2KB)

## Test plan
- [ ] `pnpm lint` エラー 0 件
- [ ] `pnpm type-check` 型エラー 0 件
- [ ] `pnpm build` ビルド成功
- [ ] ブラウザ確認: 距離順/名前順の切り替え動作
- [ ] ブラウザ確認: 位置情報未取得時の disabled 状態
- [ ] キーボード操作 (Tab, Enter/Space) でトグル可能

Closes #303 (Phase 3/6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)