### PR TITLE
chore(cleanup): clsx→cn()統一 & ドキュメント更新 (Phase 6)

### DIFF
--- a/.docs/system/project-structure.md
+++ b/.docs/system/project-structure.md
@@ -44,7 +44,10 @@ naruto-shelter-map/
 │   │   ├── filter/                 # 災害種別フィルタ
 │   │   ├── icons/
 │   │   ├── map/                    # 地図・マーカー・コントロール
-│   │   ├── mobile/                 # ボトムシート等
+│   │   ├── layout/                 # デスクトップサイドバー等
+│   │   ├── legal/                  # 利用規約モーダル
+│   │   ├── chat/                   # AI チャット（FAB・モーダル・パネル）
+│   │   ├── ui/                     # shadcn/ui コンポーネント（Button, Dialog, Drawer, Badge 等）
 │   │   ├── pwa/                    # PWA インストール・オフライン表示
 │   │   └── shelter/                # 避難所リスト・カード・詳細モーダル
 │   │

--- a/.docs/system/tech-stack.md
+++ b/.docs/system/tech-stack.md
@@ -46,9 +46,10 @@
 
 | 技術 | 用途・理由 |
 |------|------------|
-| **framer-motion** | アニメーション（ボトムシート等）。 |
+| **shadcn/ui** | Radix UI ベースのコンポーネント集（Dialog, Drawer, Button, Badge, Toggle 等）。コピー&カスタマイズ方式。 |
+| **lucide-react** | アイコンライブラリ。ツリーシェイク可能な個別インポート。 |
 | **@tanstack/react-virtual** | 仮想スクロール（避難所リスト）。 |
-| **clsx / tailwind-merge** | 条件付きクラス・クラス結合。 |
+| **clsx / tailwind-merge** | `cn()` ユーティリティでクラス結合。`src/lib/utils.ts` で定義。 |
 | **Context API** | フィルタ等のグローバルに近い状態。 |
 
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,8 +4,8 @@
 >
 > このドキュメントは、AI Coding Agents（Claude, Cursor, GitHub Copilot, etc.）がプロジェクトを理解し、適切なコードを生成するための標準規格です。
 
-**Last Updated:** 2026-02-14
-**Project Version:** 1.0.0
+**Last Updated:** 2026-02-24
+**Project Version:** 1.1.0
 **AI Agent Compatibility:** Claude Code, Cursor, GitHub Copilot, Windsurf
 
 ---
@@ -63,6 +63,8 @@
 | **React**        | UI ライブラリ（React 19）                                                       |
 | **TypeScript**   | 型安全性                                                                        |
 | **Tailwind CSS** | スタイリング（v4 Lightning CSS 統合、システムフォント使用）                     |
+| **shadcn/ui**    | Radix UI ベースの UI コンポーネント集（Dialog, Drawer, Button, Badge, Toggle 等） |
+| **lucide-react** | アイコンライブラリ（ツリーシェイク可能な個別インポート）                        |
 
 ### 地図・データ
 
@@ -113,6 +115,7 @@ naruto-shelter-map/
 │   ├── globals.css               # グローバルスタイル（Tailwind v4）
 │   ├── vite-env.d.ts             # Vite クライアント型
 │   ├── components/               # Reactコンポーネント（機能別サブフォルダ）
+│   │   ├── ui/                  # shadcn/ui コンポーネント（Button, Dialog, Drawer 等）
 │   │   ├── map/                 # 地図・マーカー・コントロール
 │   │   ├── shelter/             # 避難所リスト・カード・詳細モーダル
 │   │   ├── filter/              # 災害種別フィルタ
@@ -532,6 +535,7 @@ git branch -d feature/shelter-filter
 
 | バージョン | 日付       | 変更内容                                                                 |
 | ---------- | ---------- | ------------------------------------------------------------------------ |
+| 1.5.0      | 2026-02-24 | shadcn/ui デザインリプレース（Dialog, Drawer, Button, Badge, Toggle, lucide-react アイコン） |
 | 1.4.0      | 2026-02-12 | Next.js から Vite + React に移行（ADR-003）、PWA は vite-plugin-pwa       |
 | 1.3.0      | 2025-12-27 | 隣接地域対応（藍住町、北島町、松茂町、板野町）、ダークモード非対応を明記 |
 | 1.2.0      | 2025-12-06 | ビルド設定改善（Webpack 明示指定）、UI 改善完了、システムフォント採用    |

--- a/src/components/shelter/ShelterCard.tsx
+++ b/src/components/shelter/ShelterCard.tsx
@@ -1,4 +1,3 @@
-import { clsx } from 'clsx';
 import {
   AlertTriangleIcon,
   InfoIcon,
@@ -21,6 +20,7 @@ import {
   formatTravelTime,
   generateNavigationURL,
 } from '@/lib/navigation';
+import { cn } from '@/lib/utils';
 import type { ShelterFeature } from '@/types/shelter';
 import { ShelterCardBadges } from './ShelterCardBadges';
 import { ShelterDetailModal } from './ShelterDetailModal';
@@ -67,7 +67,7 @@ function ShelterCardComponent({
     <>
       {/* biome-ignore lint/a11y/useSemanticElements: ボタンネストを避けるためdivを使用 */}
       <div
-        className={clsx(
+        className={cn(
           'w-full cursor-pointer rounded-xl border bg-white p-4 text-left transition-all hover:shadow-lg',
           onClick && 'hover:border-blue-300',
           isSelected && 'ring-2 ring-blue-500 bg-blue-50 border-blue-300'

--- a/src/components/shelter/ShelterCardBadges.tsx
+++ b/src/components/shelter/ShelterCardBadges.tsx
@@ -1,4 +1,4 @@
-import { clsx } from 'clsx';
+import { cn } from '@/lib/utils';
 import type { ShelterFeature } from '@/types/shelter';
 
 interface ShelterCardBadgesProps {
@@ -92,7 +92,7 @@ export function ShelterCardBadges({
 
       {pets && (
         <span
-          className={clsx(
+          className={cn(
             'flex items-center gap-1 rounded-full px-2 py-0.5 text-xs',
             pets.allowed
               ? 'bg-green-50 text-green-700'


### PR DESCRIPTION
## 概要
shadcn/ui デザインリプレース（Issue #303）の最終フェーズ。コード統一とドキュメント更新を行います。

### 変更内容

#### clsx → cn() 統一
- `ShelterCard.tsx`: `clsx()` → `cn()` に変更、`clsx` 直接インポートを削除
- `ShelterCardBadges.tsx`: 同上
- `clsx` パッケージは `cn()` ユーティリティ (`src/lib/utils.ts`) 内部で引き続き使用

#### ドキュメント更新
- **tech-stack.md**: shadcn/ui, lucide-react を追加。framer-motion を削除
- **project-structure.md**: `ui/`, `layout/`, `legal/`, `chat/` ディレクトリを追加。`mobile/` を削除（Phase 4 で削除済み）
- **AGENTS.md**: 技術スタックに shadcn/ui, lucide-react を追加。ディレクトリ構造に `ui/` を追加。バージョン・更新履歴を更新

## Phase 0-6 サマリー
| Phase | 内容 | PR |
|-------|------|----|
| 0 | Tailwind v4 基盤整備 + shadcn init | #322 |
| 1 | Button, Badge, Card, Input, Checkbox | #323 |
| 2 | Dialog (Radix), Sonner (Toast) | #324 |
| 3 | ToggleGroup (Radix) | #325 |
| 4 | Drawer (vaul) + framer-motion 削除 | #326 |
| 5 | lucide-react アイコン統一 | #327 |
| 6 | clsx→cn() 統一 + ドキュメント更新 | **本PR** |

## テスト計画
- [ ] `pnpm lint` エラー 0 件
- [ ] `pnpm type-check` 型エラー 0 件
- [ ] `pnpm build` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)