### PR TITLE
feat(ui): カラートークン統一 (UIブラッシュアップ Phase 1)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,10 +23,12 @@ const ShelterMap = lazy(() =>
 );
 
 const MAP_LOADING_FALLBACK = (
-  <div className="flex h-full w-full items-center justify-center bg-gray-100">
+  <div className="flex h-full w-full items-center justify-center bg-muted">
     <div className="text-center">
-      <div className="mx-auto h-12 w-12 animate-spin rounded-full border-4 border-blue-500 border-t-transparent" />
-      <p className="mt-4 text-sm text-gray-600">地図を読み込んでいます...</p>
+      <div className="mx-auto h-12 w-12 animate-spin rounded-full border-4 border-primary/30 border-t-primary" />
+      <p className="mt-4 text-sm text-muted-foreground">
+        地図を読み込んでいます...
+      </p>
     </div>
   </div>
 );
@@ -90,8 +92,8 @@ function HomePageContent({ mainContentId }: { mainContentId: string }) {
     return (
       <div className="flex min-h-screen items-center justify-center">
         <div className="text-center">
-          <div className="mx-auto h-12 w-12 animate-spin rounded-full border-4 border-blue-500 border-t-transparent" />
-          <p className="mt-4 text-sm text-gray-600">読み込み中...</p>
+          <div className="mx-auto h-12 w-12 animate-spin rounded-full border-4 border-primary/30 border-t-primary" />
+          <p className="mt-4 text-sm text-muted-foreground">読み込み中...</p>
         </div>
       </div>
     );

--- a/src/components/chat/ChatFab.tsx
+++ b/src/components/chat/ChatFab.tsx
@@ -13,7 +13,7 @@ export function ChatFab({
     <button
       type="button"
       onClick={onClick}
-      className="flex h-12 w-12 items-center justify-center rounded-full bg-blue-600 text-white shadow-lg transition-colors hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2"
+      className="flex h-12 w-12 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-lg transition-colors hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
       aria-label={ariaLabel}
     >
       <MessageCircleIcon className="h-6 w-6" aria-hidden="true" />

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -29,7 +29,7 @@ export function ChatInput({
   return (
     <form
       onSubmit={handleSubmit}
-      className="flex gap-2 border-t border-gray-200 bg-white p-2"
+      className="flex gap-2 border-t border-border bg-card p-2"
       aria-label="避難所について質問"
     >
       <Input

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -14,7 +14,9 @@ export function ChatMessage({
     <div className={`flex ${isUser ? 'justify-end' : 'justify-start'}`}>
       <div
         className={`max-w-[85%] rounded-lg px-3 py-2 text-sm ${
-          isUser ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-900'
+          isUser
+            ? 'bg-primary text-primary-foreground'
+            : 'bg-muted text-foreground'
         }`}
       >
         <p className="whitespace-pre-line break-words">

--- a/src/components/chat/ChatModal.tsx
+++ b/src/components/chat/ChatModal.tsx
@@ -34,8 +34,8 @@ export function ChatModal({
         showCloseButton={false}
         className="inset-0 flex max-w-none translate-x-0 translate-y-0 flex-col gap-0 rounded-none border-0 p-0 pb-[env(safe-area-inset-bottom)]"
       >
-        <header className="flex shrink-0 items-center justify-between border-b border-gray-200 bg-white px-4 py-3">
-          <DialogTitle className="text-lg font-bold text-gray-900">
+        <header className="flex shrink-0 items-center justify-between border-b border-border bg-card px-4 py-3">
+          <DialogTitle className="text-lg font-bold text-foreground">
             避難所について質問
           </DialogTitle>
           <DialogDescription className="sr-only">
@@ -44,7 +44,7 @@ export function ChatModal({
           <DialogClose asChild>
             <button
               type="button"
-              className="rounded p-2 text-gray-600 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-400"
+              className="rounded p-2 text-muted-foreground hover:bg-accent focus:outline-none focus:ring-2 focus:ring-ring"
               aria-label="閉じる"
             >
               <XIcon className="h-5 w-5" aria-hidden="true" />

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -165,12 +165,12 @@ export function ChatPanel({
         />
 
         {isLoading && (
-          <p className="text-sm text-gray-500">
+          <p className="text-sm text-muted-foreground">
             避難所データを読み込み中です。
           </p>
         )}
         {!isLoading && isEmpty && (
-          <p className="text-sm text-gray-500">
+          <p className="text-sm text-muted-foreground">
             避難所について質問してみてください。例：「津波対応の避難所は？」「一番近い避難所は？」
           </p>
         )}
@@ -208,14 +208,14 @@ function LLMStatusBanner({
   switch (status) {
     case 'idle':
       return (
-        <div className="mb-3 rounded-lg border border-blue-200 bg-blue-50 p-3">
-          <p className="mb-2 text-xs text-blue-800">
+        <div className="mb-3 rounded-lg border border-primary/30 bg-primary/10 p-3">
+          <p className="mb-2 text-xs text-primary">
             AIモデルを有効にすると、より自然な回答が得られます。
           </p>
           <button
             type="button"
             onClick={onInit}
-            className="rounded-md bg-blue-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-700 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2"
+            className="rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
           >
             AIモデルを有効にする
           </button>
@@ -223,17 +223,17 @@ function LLMStatusBanner({
       );
     case 'checking':
       return (
-        <div className="mb-3 rounded-lg bg-gray-50 p-3">
-          <p className="text-xs text-gray-600">WebGPU を確認中...</p>
+        <div className="mb-3 rounded-lg bg-muted p-3">
+          <p className="text-xs text-muted-foreground">WebGPU を確認中...</p>
         </div>
       );
     case 'downloading':
       return (
-        <div className="mb-3 rounded-lg border border-blue-200 bg-blue-50 p-3">
-          <p className="mb-1 text-xs font-medium text-blue-800">
+        <div className="mb-3 rounded-lg border border-primary/30 bg-primary/10 p-3">
+          <p className="mb-1 text-xs font-medium text-primary">
             AIモデルをダウンロード中...
           </p>
-          <p className="text-xs text-blue-600 break-all">{progress}</p>
+          <p className="text-xs text-primary/80 break-all">{progress}</p>
         </div>
       );
     case 'ready':

--- a/src/components/error/ErrorBoundary.tsx
+++ b/src/components/error/ErrorBoundary.tsx
@@ -46,8 +46,8 @@ export class ErrorBoundary extends Component<
       }
 
       return (
-        <div className="flex min-h-screen flex-col items-center justify-center bg-gray-50 px-4">
-          <div className="w-full max-w-md rounded-lg bg-white p-6 shadow-lg">
+        <div className="flex min-h-screen flex-col items-center justify-center bg-muted px-4">
+          <div className="w-full max-w-md rounded-lg bg-card p-6 shadow-lg">
             {/* エラーアイコン */}
             <div className="mb-4 flex justify-center">
               <div className="rounded-full bg-red-100 p-3">
@@ -59,10 +59,10 @@ export class ErrorBoundary extends Component<
             </div>
 
             {/* エラーメッセージ */}
-            <h2 className="mb-2 text-center text-xl font-bold text-gray-900">
+            <h2 className="mb-2 text-center text-xl font-bold text-foreground">
               エラーが発生しました
             </h2>
-            <p className="mb-6 text-center text-sm text-gray-600">
+            <p className="mb-6 text-center text-sm text-muted-foreground">
               申し訳ございません。予期しないエラーが発生しました。
               <br />
               ページを再読み込みしてお試しください。
@@ -70,11 +70,11 @@ export class ErrorBoundary extends Component<
 
             {/* エラー詳細（開発環境のみ） */}
             {process.env.NODE_ENV === 'development' && (
-              <details className="mb-4 rounded bg-gray-100 p-3">
-                <summary className="cursor-pointer text-sm font-semibold text-gray-700">
+              <details className="mb-4 rounded bg-muted p-3">
+                <summary className="cursor-pointer text-sm font-semibold text-foreground/80">
                   エラー詳細（開発環境のみ）
                 </summary>
-                <pre className="mt-2 overflow-x-auto text-xs text-gray-600">
+                <pre className="mt-2 overflow-x-auto text-xs text-muted-foreground">
                   {this.state.error.message}
                   {'\n\n'}
                   {this.state.error.stack}
@@ -87,7 +87,7 @@ export class ErrorBoundary extends Component<
               <button
                 type="button"
                 onClick={this.reset}
-                className="w-full rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2 transition-colors"
+                className="w-full rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground shadow-sm hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 transition-colors"
               >
                 もう一度試す
               </button>
@@ -96,7 +96,7 @@ export class ErrorBoundary extends Component<
                 onClick={() => {
                   window.location.href = '/';
                 }}
-                className="w-full rounded-lg bg-gray-200 px-4 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2 transition-colors"
+                className="w-full rounded-lg bg-secondary px-4 py-2 text-sm font-semibold text-secondary-foreground hover:bg-secondary/80 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 transition-colors"
               >
                 ホームに戻る
               </button>

--- a/src/components/error/NetworkError.tsx
+++ b/src/components/error/NetworkError.tsx
@@ -25,17 +25,19 @@ export function NetworkError({
       <div className="w-full max-w-sm text-center">
         {/* エラーアイコン */}
         <div className="mb-4 flex justify-center">
-          <div className="rounded-full bg-gray-100 p-3">
+          <div className="rounded-full bg-muted p-3">
             <WifiOffIcon
-              className="h-12 w-12 text-gray-400"
+              className="h-12 w-12 text-muted-foreground/70"
               aria-hidden="true"
             />
           </div>
         </div>
 
         {/* エラーメッセージ */}
-        <h3 className="mb-2 text-lg font-semibold text-gray-900">{message}</h3>
-        <p className="mb-6 text-sm text-gray-600">
+        <h3 className="mb-2 text-lg font-semibold text-foreground">
+          {message}
+        </h3>
+        <p className="mb-6 text-sm text-muted-foreground">
           ネットワーク接続を確認してから、
           <br />
           再度お試しください。

--- a/src/components/filter/DisasterTypeFilter.tsx
+++ b/src/components/filter/DisasterTypeFilter.tsx
@@ -134,9 +134,9 @@ export function DisasterTypeFilter(): ReactElement {
   const { selectedDisasters, toggleDisaster, clearFilters } = useFilter();
 
   return (
-    <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+    <div className="rounded-lg border border-border bg-card p-4 shadow-sm">
       <div className="mb-3 flex items-center justify-between">
-        <h3 className="text-sm font-semibold text-gray-900">災害種別</h3>
+        <h3 className="text-sm font-semibold text-foreground">災害種別</h3>
         {selectedDisasters.length > 0 && (
           <Button
             variant="link"
@@ -158,7 +158,9 @@ export function DisasterTypeFilter(): ReactElement {
               key={disaster}
               htmlFor={`filter-${disaster}`}
               className={`flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 transition-colors ${
-                isSelected ? 'bg-blue-50 hover:bg-blue-100' : 'hover:bg-gray-50'
+                isSelected
+                  ? 'bg-primary/10 hover:bg-primary/15'
+                  : 'hover:bg-accent'
               }`}
             >
               <Checkbox
@@ -169,12 +171,12 @@ export function DisasterTypeFilter(): ReactElement {
               />
               <IconComponent
                 className={`h-5 w-5 shrink-0 transition-colors ${
-                  isSelected ? 'text-blue-600' : 'text-gray-600'
+                  isSelected ? 'text-primary' : 'text-muted-foreground'
                 }`}
               />
               <span
                 className={`text-sm transition-colors ${
-                  isSelected ? 'text-blue-900 font-medium' : 'text-gray-700'
+                  isSelected ? 'text-primary font-medium' : 'text-foreground/80'
                 }`}
               >
                 {disaster}
@@ -185,8 +187,8 @@ export function DisasterTypeFilter(): ReactElement {
       </div>
 
       {selectedDisasters.length > 0 && (
-        <div className="mt-3 border-t border-gray-200 pt-3">
-          <p className="text-xs text-gray-600">
+        <div className="mt-3 border-t border-border pt-3">
+          <p className="text-xs text-muted-foreground">
             {selectedDisasters.length}件の災害種別でフィルタ中
           </p>
         </div>

--- a/src/components/layout/DesktopSidebar.tsx
+++ b/src/components/layout/DesktopSidebar.tsx
@@ -52,12 +52,12 @@ export function DesktopSidebar({
 }: DesktopSidebarProps): React.JSX.Element {
   return (
     <aside
-      className="flex h-full w-96 flex-col border-r bg-white"
+      className="flex h-full w-96 flex-col border-r bg-card"
       aria-label="避難所フィルタとリスト"
     >
       <header className="border-b p-4">
         <div className="mb-2 flex items-center justify-between gap-2">
-          <h1 className="flex items-center gap-2 text-xl font-bold text-gray-900">
+          <h1 className="flex items-center gap-2 text-xl font-bold text-foreground">
             <img
               src="/icon.svg"
               alt=""
@@ -79,7 +79,7 @@ export function DesktopSidebar({
             >
               {isRefreshing ? (
                 <span
-                  className="size-4 animate-spin rounded-full border-2 border-gray-300 border-t-blue-600"
+                  className="size-4 animate-spin rounded-full border-2 border-primary/30 border-t-primary"
                   aria-hidden
                 />
               ) : (
@@ -97,7 +97,7 @@ export function DesktopSidebar({
             </Button>
           </div>
         </div>
-        <p className="text-sm text-gray-700">
+        <p className="text-sm text-muted-foreground">
           {listFilter === 'chat'
             ? '避難所について質問'
             : listFilter === 'favorites'
@@ -105,7 +105,7 @@ export function DesktopSidebar({
               : `${filteredShelters.length}件の避難所`}
           {listFilter === 'all' &&
             filteredShelters.length !== allSheltersCount && (
-              <span className="ml-1 text-gray-700">
+              <span className="ml-1 text-muted-foreground">
                 （全{allSheltersCount}件中）
               </span>
             )}
@@ -114,7 +114,7 @@ export function DesktopSidebar({
 
       <div className="border-b p-4">
         <div
-          className="flex rounded-lg border border-gray-200 p-1"
+          className="flex rounded-lg border border-border p-1"
           role="tablist"
           aria-label="リストの表示"
         >
@@ -124,8 +124,8 @@ export function DesktopSidebar({
             aria-selected={listFilter === 'all'}
             className={`flex-1 rounded-md px-3 py-2 text-sm font-medium transition-colors ${
               listFilter === 'all'
-                ? 'bg-gray-100 text-gray-900'
-                : 'text-gray-600 hover:bg-gray-50'
+                ? 'bg-accent text-accent-foreground'
+                : 'text-muted-foreground hover:bg-accent/50'
             }`}
             onClick={() => onListFilterChange('all')}
           >
@@ -137,8 +137,8 @@ export function DesktopSidebar({
             aria-selected={listFilter === 'favorites'}
             className={`flex-1 rounded-md px-3 py-2 text-sm font-medium transition-colors ${
               listFilter === 'favorites'
-                ? 'bg-gray-100 text-gray-900'
-                : 'text-gray-600 hover:bg-gray-50'
+                ? 'bg-accent text-accent-foreground'
+                : 'text-muted-foreground hover:bg-accent/50'
             }`}
             onClick={() => onListFilterChange('favorites')}
           >
@@ -150,8 +150,8 @@ export function DesktopSidebar({
             aria-selected={listFilter === 'chat'}
             className={`flex-1 rounded-md px-3 py-2 text-sm font-medium transition-colors ${
               listFilter === 'chat'
-                ? 'bg-gray-100 text-gray-900'
-                : 'text-gray-600 hover:bg-gray-50'
+                ? 'bg-accent text-accent-foreground'
+                : 'text-muted-foreground hover:bg-accent/50'
             }`}
             onClick={() => onListFilterChange('chat')}
           >

--- a/src/components/legal/TermsModal.tsx
+++ b/src/components/legal/TermsModal.tsx
@@ -28,8 +28,8 @@ export function TermsModal({
         className="bottom-0 left-0 right-0 top-auto max-h-[90vh] w-full max-w-lg translate-x-0 translate-y-0 gap-0 overflow-y-auto rounded-t-2xl border-0 p-0 shadow-2xl sm:bottom-auto sm:left-[50%] sm:right-auto sm:top-[50%] sm:translate-x-[-50%] sm:translate-y-[-50%] sm:rounded-2xl"
       >
         {/* ヘッダー */}
-        <div className="sticky top-0 z-10 flex items-center justify-between rounded-t-2xl border-b border-gray-200 bg-white p-4">
-          <DialogTitle className="text-lg font-bold text-gray-900">
+        <div className="sticky top-0 z-10 flex items-center justify-between rounded-t-2xl border-b border-border bg-card p-4">
+          <DialogTitle className="text-lg font-bold text-foreground">
             利用規約
           </DialogTitle>
           <DialogDescription className="sr-only">
@@ -38,7 +38,7 @@ export function TermsModal({
           <DialogClose asChild>
             <button
               type="button"
-              className="rounded-full p-2 transition-colors hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2"
+              className="rounded-full p-2 transition-colors hover:bg-accent focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
               aria-label="閉じる"
             >
               <XIcon className="h-6 w-6" aria-hidden="true" />
@@ -47,7 +47,7 @@ export function TermsModal({
         </div>
 
         {/* コンテンツ */}
-        <div className="space-y-6 p-4 text-sm leading-relaxed text-gray-700">
+        <div className="space-y-6 p-4 text-sm leading-relaxed text-foreground/80">
           <TermsSection title="第1条（サービス概要）">
             <p>
               本サービス「鳴門避難マップ」（以下「本サービス」）は、
@@ -127,8 +127,10 @@ export function TermsModal({
             </p>
           </TermsSection>
 
-          <section className="border-t border-gray-200 pt-4">
-            <p className="text-xs text-gray-500">制定日: 2026年2月20日</p>
+          <section className="border-t border-border pt-4">
+            <p className="text-xs text-muted-foreground">
+              制定日: 2026年2月20日
+            </p>
           </section>
         </div>
       </DialogContent>
@@ -145,7 +147,7 @@ function TermsSection({
 }): React.ReactNode {
   return (
     <section>
-      <h3 className="mb-2 text-sm font-semibold text-gray-900">{title}</h3>
+      <h3 className="mb-2 text-sm font-semibold text-foreground">{title}</h3>
       {children}
     </section>
   );

--- a/src/components/map/CurrentLocationButton.tsx
+++ b/src/components/map/CurrentLocationButton.tsx
@@ -24,7 +24,7 @@ function getButtonContent(
         <LoaderCircleIcon className="h-5 w-5 animate-spin" aria-hidden="true" />
       ),
       label: '現在地を取得中',
-      iconColor: 'text-blue-600',
+      iconColor: 'text-primary',
     };
   }
 
@@ -32,7 +32,7 @@ function getButtonContent(
     return {
       icon: <AlertCircleIcon className="h-5 w-5" aria-hidden="true" />,
       label: getErrorMessage(error),
-      iconColor: 'text-red-600',
+      iconColor: 'text-destructive',
     };
   }
 
@@ -45,7 +45,7 @@ function getButtonContent(
         </svg>
       ),
       label: '現在地を表示中',
-      iconColor: 'text-blue-600',
+      iconColor: 'text-primary',
     };
   }
 
@@ -57,7 +57,7 @@ function getButtonContent(
       </svg>
     ),
     label: '現在地を表示',
-    iconColor: 'text-gray-700',
+    iconColor: 'text-muted-foreground',
   };
 }
 
@@ -93,9 +93,9 @@ export const CurrentLocationButton: FC<CurrentLocationButtonProps> = ({
       disabled={state === 'loading'}
       className={cn(
         // Googleマップ風: 円形、白背景、影
-        'flex h-12 w-12 items-center justify-center rounded-full bg-white shadow-lg transition-all',
+        'flex h-12 w-12 items-center justify-center rounded-full bg-card shadow-lg transition-all',
         'hover:shadow-xl active:shadow-md',
-        'focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2',
+        'focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
         'disabled:cursor-not-allowed disabled:opacity-75',
         iconColor,
         className

--- a/src/components/map/FilterButton.tsx
+++ b/src/components/map/FilterButton.tsx
@@ -14,13 +14,15 @@ export function FilterButton() {
       <Button
         variant="outline"
         onClick={() => setIsOpen(!isOpen)}
-        className={`rounded-full bg-white shadow-lg hover:shadow-xl ${hasActiveFilters ? 'border-2 border-blue-500' : ''}`}
+        className={`rounded-full bg-card shadow-lg hover:shadow-xl ${hasActiveFilters ? 'border-2 border-primary' : ''}`}
         aria-label="フィルタ"
         aria-expanded={isOpen}
       >
-        <span className="text-sm font-medium text-gray-700">フィルタ</span>
+        <span className="text-sm font-medium text-muted-foreground">
+          フィルタ
+        </span>
         {hasActiveFilters && (
-          <span className="flex h-5 w-5 items-center justify-center rounded-full bg-blue-500 text-xs font-semibold text-white">
+          <span className="flex h-5 w-5 items-center justify-center rounded-full bg-primary text-xs font-semibold text-primary-foreground">
             {selectedDisasters.length}
           </span>
         )}
@@ -36,7 +38,7 @@ export function FilterButton() {
             aria-hidden="true"
           />
           {/* ドロワー */}
-          <div className="absolute left-4 top-16 z-50 w-80 max-w-[calc(100vw-2rem)] rounded-lg bg-white shadow-2xl lg:hidden">
+          <div className="absolute left-4 top-16 z-50 w-80 max-w-[calc(100vw-2rem)] rounded-lg bg-card shadow-2xl lg:hidden">
             <div className="max-h-[calc(100vh-6rem)] overflow-y-auto p-4">
               <DisasterTypeFilter />
             </div>

--- a/src/components/map/MapSearchBar.tsx
+++ b/src/components/map/MapSearchBar.tsx
@@ -40,7 +40,7 @@ export const MapSearchBar: FC<MapSearchBarProps> = ({
     >
       <div
         className={`
-          flex items-center rounded-lg bg-white shadow-lg transition-shadow
+          flex items-center rounded-lg bg-card shadow-lg transition-shadow
           ${isFocused ? 'shadow-2xl' : 'shadow-lg hover:shadow-xl'}
         `}
       >
@@ -49,7 +49,7 @@ export const MapSearchBar: FC<MapSearchBarProps> = ({
           <button
             type="button"
             onClick={onMenuClick}
-            className="flex h-11 w-11 items-center justify-center text-gray-600 transition-colors hover:text-gray-900"
+            className="flex h-11 w-11 items-center justify-center text-muted-foreground transition-colors hover:text-foreground"
             aria-label="メニュー"
           >
             <MenuIcon className="h-6 w-6" aria-hidden="true" />
@@ -57,7 +57,7 @@ export const MapSearchBar: FC<MapSearchBarProps> = ({
         )}
 
         {/* 検索アイコン */}
-        <div className="flex h-11 w-11 items-center justify-center text-gray-400">
+        <div className="flex h-11 w-11 items-center justify-center text-muted-foreground/70">
           <SearchIcon className="h-5 w-5" aria-hidden="true" />
         </div>
 
@@ -69,7 +69,7 @@ export const MapSearchBar: FC<MapSearchBarProps> = ({
           onFocus={() => setIsFocused(true)}
           onBlur={() => setIsFocused(false)}
           placeholder={placeholder}
-          className="flex-1 border-none bg-transparent py-3 pr-2 text-gray-900 placeholder-gray-500 outline-none"
+          className="flex-1 border-none bg-transparent py-3 pr-2 text-foreground placeholder-muted-foreground outline-none"
           aria-label="避難所を検索"
         />
 
@@ -78,7 +78,7 @@ export const MapSearchBar: FC<MapSearchBarProps> = ({
           <button
             type="button"
             onClick={handleClear}
-            className="flex h-11 w-11 items-center justify-center text-gray-400 transition-colors hover:text-gray-600"
+            className="flex h-11 w-11 items-center justify-center text-muted-foreground/70 transition-colors hover:text-muted-foreground"
             aria-label="検索をクリア"
           >
             <XIcon className="h-5 w-5" aria-hidden="true" />
@@ -90,7 +90,7 @@ export const MapSearchBar: FC<MapSearchBarProps> = ({
           <button
             type="button"
             onClick={onCurrentLocationClick}
-            className="flex h-11 w-11 items-center justify-center text-gray-600 transition-colors hover:text-gray-900"
+            className="flex h-11 w-11 items-center justify-center text-muted-foreground transition-colors hover:text-foreground"
             aria-label="現在地を表示"
           >
             <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">

--- a/src/components/map/MapSkeleton.tsx
+++ b/src/components/map/MapSkeleton.tsx
@@ -6,11 +6,13 @@ import type { ReactElement } from 'react';
  */
 export function MapSkeleton(): ReactElement {
   return (
-    <div className="h-full w-full animate-pulse bg-gray-200">
+    <div className="h-full w-full animate-pulse bg-muted">
       <div className="flex h-full w-full items-center justify-center">
         <div className="text-center">
-          <div className="mx-auto h-12 w-12 animate-spin rounded-full border-4 border-blue-500 border-t-transparent" />
-          <p className="mt-4 text-sm text-gray-600">地図を読み込み中...</p>
+          <div className="mx-auto h-12 w-12 animate-spin rounded-full border-4 border-primary/30 border-t-primary" />
+          <p className="mt-4 text-sm text-muted-foreground">
+            地図を読み込み中...
+          </p>
         </div>
       </div>
     </div>

--- a/src/components/map/ShelterPopup.tsx
+++ b/src/components/map/ShelterPopup.tsx
@@ -28,8 +28,8 @@ export function ShelterPopup({
       className="shelter-popup"
     >
       <div className="p-4">
-        <h3 className="mb-2 text-base font-bold text-gray-900">{name}</h3>
-        <div className="space-y-1 text-sm text-gray-700 mb-3">
+        <h3 className="mb-2 text-base font-bold text-foreground">{name}</h3>
+        <div className="space-y-1 text-sm text-foreground/80 mb-3">
           <p>
             <span className="font-semibold">住所:</span> {address}
           </p>
@@ -47,7 +47,7 @@ export function ShelterPopup({
           <button
             type="button"
             onClick={() => onShowDetail?.(shelter)}
-            className="w-full flex items-center justify-center gap-2 px-3 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2"
+            className="w-full flex items-center justify-center gap-2 px-3 py-2 text-sm font-medium text-secondary-foreground bg-secondary hover:bg-secondary/80 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
             aria-label={`${name}の詳細を見る`}
           >
             <svg
@@ -76,7 +76,7 @@ export function ShelterPopup({
               );
               window.open(url, '_blank', 'noopener,noreferrer');
             }}
-            className="w-full flex items-center justify-center gap-2 px-3 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2"
+            className="w-full flex items-center justify-center gap-2 px-3 py-2 text-sm font-medium text-primary-foreground bg-primary hover:bg-primary/90 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
             aria-label={`${name}への経路案内`}
           >
             <svg

--- a/src/components/pwa/InstallPrompt.tsx
+++ b/src/components/pwa/InstallPrompt.tsx
@@ -28,21 +28,18 @@ export function InstallPrompt(): ReactElement | null {
 
   return (
     <div
-      className="fixed bottom-4 left-4 right-4 z-50 rounded-lg bg-white p-4 shadow-xl ring-1 ring-black ring-opacity-5 lg:left-auto lg:right-4 lg:w-96"
+      className="fixed bottom-4 left-4 right-4 z-50 rounded-lg bg-card p-4 shadow-xl ring-1 ring-border lg:left-auto lg:right-4 lg:w-96"
       role="alert"
     >
       <div className="flex items-start gap-3">
         <div className="flex-shrink-0">
-          <SmartphoneIcon
-            className="h-6 w-6 text-blue-600"
-            aria-hidden="true"
-          />
+          <SmartphoneIcon className="h-6 w-6 text-primary" aria-hidden="true" />
         </div>
         <div className="flex-1">
-          <h3 className="text-sm font-semibold text-gray-900">
+          <h3 className="text-sm font-semibold text-foreground">
             アプリをインストール
           </h3>
-          <p className="mt-1 text-sm text-gray-600">
+          <p className="mt-1 text-sm text-muted-foreground">
             ホーム画面に追加して、オフラインでも避難所情報を確認できます。
           </p>
           <div className="mt-3 flex gap-2">

--- a/src/components/pwa/OfflineIndicator.tsx
+++ b/src/components/pwa/OfflineIndicator.tsx
@@ -14,7 +14,7 @@ export function OfflineIndicator(): ReactElement | null {
 
   return (
     <div
-      className="fixed bottom-4 left-1/2 z-50 -translate-x-1/2 rounded-lg bg-gray-900 px-4 py-2 text-sm text-white shadow-lg"
+      className="fixed bottom-4 left-1/2 z-50 -translate-x-1/2 rounded-lg bg-foreground px-4 py-2 text-sm text-background shadow-lg"
       role="alert"
       aria-live="polite"
     >

--- a/src/components/pwa/UpdateNotification.tsx
+++ b/src/components/pwa/UpdateNotification.tsx
@@ -32,19 +32,19 @@ export function UpdateNotification(): ReactElement | null {
 
   return (
     <div
-      className="fixed bottom-4 left-4 right-4 z-50 rounded-lg bg-white p-4 shadow-xl ring-1 ring-black ring-opacity-5 lg:left-auto lg:right-4 lg:w-96"
+      className="fixed bottom-4 left-4 right-4 z-50 rounded-lg bg-card p-4 shadow-xl ring-1 ring-border lg:left-auto lg:right-4 lg:w-96"
       role="alert"
       aria-live="polite"
     >
       <div className="flex items-start gap-3">
         <div className="flex-shrink-0">
-          <RefreshCwIcon className="h-6 w-6 text-blue-600" aria-hidden="true" />
+          <RefreshCwIcon className="h-6 w-6 text-primary" aria-hidden="true" />
         </div>
         <div className="flex-1 min-w-0">
-          <h3 className="text-sm font-semibold text-gray-900">
+          <h3 className="text-sm font-semibold text-foreground">
             アプリの更新が利用可能です
           </h3>
-          <p className="mt-1 text-sm text-gray-600">
+          <p className="mt-1 text-sm text-muted-foreground">
             最新バージョンを利用するには、ページを更新してください。
           </p>
           <div className="mt-3 flex gap-2">

--- a/src/components/shelter/ShelterCard.tsx
+++ b/src/components/shelter/ShelterCard.tsx
@@ -68,9 +68,9 @@ function ShelterCardComponent({
       {/* biome-ignore lint/a11y/useSemanticElements: ボタンネストを避けるためdivを使用 */}
       <div
         className={cn(
-          'w-full cursor-pointer rounded-xl border bg-white p-4 text-left transition-all hover:shadow-lg',
-          onClick && 'hover:border-blue-300',
-          isSelected && 'ring-2 ring-blue-500 bg-blue-50 border-blue-300'
+          'w-full cursor-pointer rounded-xl border bg-card p-4 text-left transition-all hover:shadow-lg',
+          onClick && 'hover:border-primary/50',
+          isSelected && 'ring-2 ring-ring bg-primary/10 border-primary/50'
         )}
         onClick={onClick}
         role="button"
@@ -86,7 +86,7 @@ function ShelterCardComponent({
       >
         {/* ヘッダー: 名前 + お気に入りボタン */}
         <div className="mb-2 flex items-start justify-between gap-2">
-          <h3 className="flex-1 text-base font-semibold text-gray-900 leading-tight">
+          <h3 className="flex-1 text-base font-semibold text-foreground leading-tight">
             {name}
           </h3>
           {/* お気に入りボタン */}
@@ -97,7 +97,7 @@ function ShelterCardComponent({
                 e.stopPropagation();
                 onToggleFavorite(id);
               }}
-              className="flex items-center justify-center rounded-full p-1 transition-colors hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2"
+              className="flex items-center justify-center rounded-full p-1 transition-colors hover:bg-accent focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
               aria-label={
                 isFavorite ? 'お気に入りから削除' : 'お気に入りに追加'
               }
@@ -135,13 +135,13 @@ function ShelterCardComponent({
 
         {/* 距離と方向（Google Maps風） */}
         {distance !== null && distance !== undefined && (
-          <div className="mb-2 flex items-center gap-2 text-sm text-gray-600">
-            <span className="font-medium text-gray-900">
+          <div className="mb-2 flex items-center gap-2 text-sm text-muted-foreground">
+            <span className="font-medium text-foreground">
               {formatDistance(distance)}
             </span>
             {directionJa && (
               <>
-                <span className="text-gray-400">•</span>
+                <span className="text-muted-foreground/70">•</span>
                 <span>{directionJa}方向</span>
               </>
             )}
@@ -149,16 +149,16 @@ function ShelterCardComponent({
         )}
 
         {/* 住所（常に表示） */}
-        <p className="flex items-start gap-1.5 text-sm text-gray-600 mb-2">
+        <p className="flex items-start gap-1.5 text-sm text-muted-foreground mb-2">
           <MapPinIcon
-            className="mt-0.5 h-4 w-4 shrink-0 text-gray-400"
+            className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground/70"
             aria-hidden="true"
           />
           <span className="flex-1 leading-tight">{address}</span>
         </p>
 
         {/* 追加情報（コンパクトに1行で表示） */}
-        <div className="mb-2 flex flex-wrap items-center gap-2 text-sm text-gray-800">
+        <div className="mb-2 flex flex-wrap items-center gap-2 text-sm text-foreground">
           {/* 災害種別 */}
           <span className="flex items-center gap-1">
             <AlertTriangleIcon
@@ -180,7 +180,7 @@ function ShelterCardComponent({
         </div>
 
         {/* アクションボタン */}
-        <div className="flex items-center gap-2 pt-2 border-t border-gray-200">
+        <div className="flex items-center gap-2 pt-2 border-t border-border">
           {/* 詳細を見るボタン（onShowDetail ありなら地図側でモーダルを開く） */}
           <Button
             variant="secondary"
@@ -221,7 +221,7 @@ function ShelterCardComponent({
                 <MapIcon className="size-4" aria-hidden="true" />
                 <span className="truncate">経路案内</span>
               </Button>
-              <div className="flex items-center gap-2 text-sm text-gray-700">
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
                 <span
                   className="whitespace-nowrap"
                   title={`徒歩: ${formatTravelTime(
@@ -230,7 +230,7 @@ function ShelterCardComponent({
                 >
                   🚶 {formatTravelTime(estimateWalkingTime(distance))}
                 </span>
-                <span className="text-gray-500">|</span>
+                <span className="text-muted-foreground/70">|</span>
                 <span
                   className="whitespace-nowrap"
                   title={`車: ${formatTravelTime(

--- a/src/components/shelter/ShelterDetailModal.tsx
+++ b/src/components/shelter/ShelterDetailModal.tsx
@@ -66,9 +66,9 @@ export function ShelterDetailModal({
         className="bottom-0 left-0 right-0 top-auto max-h-[90vh] w-full max-w-lg translate-x-0 translate-y-0 gap-0 overflow-y-auto rounded-t-2xl border-0 p-0 shadow-2xl sm:bottom-auto sm:left-[50%] sm:right-auto sm:top-[50%] sm:translate-x-[-50%] sm:translate-y-[-50%] sm:rounded-2xl"
       >
         {/* ヘッダー */}
-        <div className="sticky top-0 z-10 flex items-start justify-between gap-4 rounded-t-2xl border-b border-gray-200 bg-white p-4">
+        <div className="sticky top-0 z-10 flex items-start justify-between gap-4 rounded-t-2xl border-b border-border bg-card p-4">
           <div className="flex-1">
-            <DialogTitle className="text-lg font-bold text-gray-900 leading-tight">
+            <DialogTitle className="text-lg font-bold text-foreground leading-tight">
               {name}
             </DialogTitle>
             <DialogDescription className="sr-only">
@@ -82,7 +82,7 @@ export function ShelterDetailModal({
               <button
                 type="button"
                 onClick={() => onToggleFavorite(id)}
-                className="rounded-full p-2 transition-colors hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2"
+                className="rounded-full p-2 transition-colors hover:bg-accent focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
                 aria-label={
                   isFavorite ? 'お気に入りから削除' : 'お気に入りに追加'
                 }
@@ -133,9 +133,9 @@ export function ShelterDetailModal({
         <div className="p-4 space-y-4">
           {/* 住所 */}
           <section>
-            <h3 className="mb-2 flex items-center gap-2 text-base font-semibold text-gray-900">
+            <h3 className="mb-2 flex items-center gap-2 text-base font-semibold text-foreground">
               <MapPinIcon
-                className="h-5 w-5 text-gray-600"
+                className="h-5 w-5 text-muted-foreground"
                 aria-hidden="true"
               />
               所在地
@@ -143,7 +143,7 @@ export function ShelterDetailModal({
             <button
               type="button"
               onClick={() => copyAddress(address)}
-              className="group flex items-center gap-2 text-sm text-gray-700 hover:text-blue-600 transition-colors rounded focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2"
+              className="group flex items-center gap-2 text-sm text-foreground/80 hover:text-primary transition-colors rounded focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
               aria-label={`住所をコピー: ${address}`}
             >
               <span>{address}</span>
@@ -154,7 +154,7 @@ export function ShelterDetailModal({
                 />
               ) : (
                 <CopyIcon
-                  className="h-4 w-4 shrink-0 text-gray-400 group-hover:text-blue-500 transition-colors"
+                  className="h-4 w-4 shrink-0 text-muted-foreground/70 group-hover:text-primary transition-colors"
                   aria-hidden="true"
                 />
               )}
@@ -163,8 +163,8 @@ export function ShelterDetailModal({
 
           {/* 距離（ある場合のみ） */}
           {distance !== null && distance !== undefined && (
-            <section className="rounded-lg bg-blue-50 p-3">
-              <p className="flex items-center gap-2 text-sm text-blue-900">
+            <section className="rounded-lg bg-primary/10 p-3">
+              <p className="flex items-center gap-2 text-sm text-primary">
                 <LocateIcon className="h-5 w-5" aria-hidden="true" />
                 <span className="font-medium">
                   現在地から {formatDistance(distance)}
@@ -175,9 +175,9 @@ export function ShelterDetailModal({
 
           {/* 災害種別 */}
           <section>
-            <h3 className="mb-2 flex items-center gap-2 text-base font-semibold text-gray-900">
+            <h3 className="mb-2 flex items-center gap-2 text-base font-semibold text-foreground">
               <AlertTriangleIcon
-                className="h-5 w-5 text-gray-600"
+                className="h-5 w-5 text-muted-foreground"
                 aria-hidden="true"
               />
               対応災害種別
@@ -198,30 +198,30 @@ export function ShelterDetailModal({
           {/* 収容人数（ある場合のみ） */}
           {capacity && (
             <section>
-              <h3 className="mb-2 flex items-center gap-2 text-base font-semibold text-gray-900">
+              <h3 className="mb-2 flex items-center gap-2 text-base font-semibold text-foreground">
                 <UsersIcon
-                  className="h-5 w-5 text-gray-600"
+                  className="h-5 w-5 text-muted-foreground"
                   aria-hidden="true"
                 />
                 収容人数
               </h3>
-              <p className="text-sm text-gray-700">{capacity}人</p>
+              <p className="text-sm text-foreground/80">{capacity}人</p>
             </section>
           )}
 
           {/* 連絡先（ある場合のみ） */}
           {contact && (
             <section>
-              <h3 className="mb-2 flex items-center gap-2 text-base font-semibold text-gray-900">
+              <h3 className="mb-2 flex items-center gap-2 text-base font-semibold text-foreground">
                 <PhoneIcon
-                  className="h-5 w-5 text-gray-600"
+                  className="h-5 w-5 text-muted-foreground"
                   aria-hidden="true"
                 />
                 連絡先
               </h3>
               <a
                 href={`tel:${contact}`}
-                className="text-sm text-blue-600 hover:underline focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2 rounded"
+                className="text-sm text-primary hover:underline focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 rounded"
               >
                 {contact}
               </a>
@@ -249,8 +249,8 @@ export function ShelterDetailModal({
           )}
 
           {/* データソース */}
-          <section className="border-t border-gray-200 pt-4">
-            <p className="text-sm text-gray-600">
+          <section className="border-t border-border pt-4">
+            <p className="text-sm text-muted-foreground">
               データ提供: {shelter.properties.source}
               <br />
               更新日: {shelter.properties.updatedAt}
@@ -259,7 +259,7 @@ export function ShelterDetailModal({
         </div>
 
         {/* フッター: アクションボタン */}
-        <div className="sticky bottom-0 border-t border-gray-200 bg-white p-4">
+        <div className="sticky bottom-0 border-t border-border bg-card p-4">
           <Button
             className="w-full py-3"
             size="lg"

--- a/src/components/shelter/ShelterDetailSections.tsx
+++ b/src/components/shelter/ShelterDetailSections.tsx
@@ -20,8 +20,11 @@ export function FacilitiesSection({
 }): React.JSX.Element {
   return (
     <section>
-      <h3 className="mb-2 flex items-center gap-2 text-base font-semibold text-gray-900">
-        <Building2Icon className="h-5 w-5 text-gray-600" aria-hidden="true" />
+      <h3 className="mb-2 flex items-center gap-2 text-base font-semibold text-foreground">
+        <Building2Icon
+          className="h-5 w-5 text-muted-foreground"
+          aria-hidden="true"
+        />
         設備情報
       </h3>
       <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
@@ -115,8 +118,11 @@ export function AccessibilitySection({
 }): React.JSX.Element {
   return (
     <section>
-      <h3 className="mb-2 flex items-center gap-2 text-base font-semibold text-gray-900">
-        <UserIcon className="h-5 w-5 text-gray-600" aria-hidden="true" />
+      <h3 className="mb-2 flex items-center gap-2 text-base font-semibold text-foreground">
+        <UserIcon
+          className="h-5 w-5 text-muted-foreground"
+          aria-hidden="true"
+        />
         バリアフリー情報
       </h3>
       <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
@@ -193,8 +199,11 @@ export function AccessibilitySection({
 export function PetSection({ pets }: { pets: PetPolicy }): React.JSX.Element {
   return (
     <section>
-      <h3 className="mb-2 flex items-center gap-2 text-base font-semibold text-gray-900">
-        <PawPrintIcon className="h-5 w-5 text-gray-600" aria-hidden="true" />
+      <h3 className="mb-2 flex items-center gap-2 text-base font-semibold text-foreground">
+        <PawPrintIcon
+          className="h-5 w-5 text-muted-foreground"
+          aria-hidden="true"
+        />
         ペット同伴
       </h3>
       <div className="space-y-2">
@@ -234,8 +243,11 @@ export function OperationStatusSection({
 }): React.JSX.Element {
   return (
     <section>
-      <h3 className="mb-2 flex items-center gap-2 text-base font-semibold text-gray-900">
-        <ClockIcon className="h-5 w-5 text-gray-600" aria-hidden="true" />
+      <h3 className="mb-2 flex items-center gap-2 text-base font-semibold text-foreground">
+        <ClockIcon
+          className="h-5 w-5 text-muted-foreground"
+          aria-hidden="true"
+        />
         開設状況
       </h3>
       <div className="space-y-2">
@@ -257,18 +269,18 @@ export function OperationStatusSection({
             )}
           </div>
         ) : (
-          <div className="rounded-lg bg-gray-50 px-3 py-2">
-            <p className="flex items-center gap-2 text-sm font-medium text-gray-900">
+          <div className="rounded-lg bg-muted px-3 py-2">
+            <p className="flex items-center gap-2 text-sm font-medium text-foreground">
               <XIcon className="h-4 w-4" aria-hidden="true" />
               閉鎖中
             </p>
             {operationStatus.lastUpdated && (
-              <p className="mt-1 text-sm text-gray-800">
+              <p className="mt-1 text-sm text-foreground/80">
                 最終更新: {operationStatus.lastUpdated}
               </p>
             )}
             {operationStatus.notes && (
-              <p className="mt-1 text-sm text-gray-800">
+              <p className="mt-1 text-sm text-foreground/80">
                 {operationStatus.notes}
               </p>
             )}

--- a/src/components/shelter/SortToggle.tsx
+++ b/src/components/shelter/SortToggle.tsx
@@ -32,7 +32,7 @@ export function SortToggle({
         value="distance"
         aria-label="距離順でソート"
         title={disabled ? '現在地を取得してください' : '距離順でソート'}
-        className="flex flex-1 items-center justify-center gap-1.5 rounded-lg px-3 py-2 data-[state=on]:bg-blue-500 data-[state=on]:text-white data-[state=on]:shadow-md"
+        className="flex flex-1 items-center justify-center gap-1.5 rounded-lg px-3 py-2 data-[state=on]:bg-primary data-[state=on]:text-primary-foreground data-[state=on]:shadow-md"
       >
         <svg
           className="h-4 w-4"
@@ -48,7 +48,7 @@ export function SortToggle({
       <ToggleGroupItem
         value="name"
         aria-label="名前順でソート"
-        className="flex flex-1 items-center justify-center gap-1.5 rounded-lg px-3 py-2 data-[state=on]:bg-blue-500 data-[state=on]:text-white data-[state=on]:shadow-md"
+        className="flex flex-1 items-center justify-center gap-1.5 rounded-lg px-3 py-2 data-[state=on]:bg-primary data-[state=on]:text-primary-foreground data-[state=on]:shadow-md"
       >
         <ArrowDownAZIcon className="h-4 w-4" aria-hidden="true" />
         <span>名前順</span>

--- a/src/globals.css
+++ b/src/globals.css
@@ -32,12 +32,12 @@
   /* リンクのデフォルトスタイル */
   a:not(.skip-link):not([class*="maplibre"]) {
     @apply underline underline-offset-2;
-    @apply text-blue-600 hover:text-blue-700;
+    @apply text-primary hover:text-primary/80;
   }
 
   /* リンクのフォーカススタイル */
   a:focus-visible {
-    @apply outline-none ring-2 ring-blue-500 ring-offset-2;
+    @apply outline-none ring-2 ring-ring ring-offset-2;
   }
 
   /* 地図コンテナのCLS対策 */
@@ -52,7 +52,7 @@
 
 /* MapLibre Popup カスタムスタイル */
 .maplibregl-popup-content {
-  @apply rounded-2xl shadow-lg bg-white;
+  @apply rounded-2xl shadow-lg bg-card;
   padding: 0 !important;
   border-radius: 1rem !important; /* 角丸を確実に適用 */
 }
@@ -62,7 +62,7 @@
 }
 
 .shelter-popup .maplibregl-popup-close-button {
-  @apply text-gray-400 hover:text-gray-600;
+  @apply text-muted-foreground hover:text-foreground;
   font-size: 20px;
   padding: 8px;
 }


### PR DESCRIPTION
## 概要

shadcn/ui の CSS 変数トークンシステムを活用し、全コンポーネントのハードコードされた Tailwind カラークラスをセマンティックトークンに統一しました。

## 変更内容

- **24ファイル** で約 **150箇所** のカラートークンを置換
- `bg-blue-600` → `bg-primary`, `text-gray-900` → `text-foreground` 等
- `bg-white` → `bg-card`, `bg-gray-100` → `bg-muted` 等
- `border-gray-200` → `border-border`, `ring-blue-500` → `ring-ring` 等
- ドメイン固有色（災害種別バッジ、設備ステータス、ペット可否、お気に入りハート）は保持

### 対象カテゴリ

| カテゴリ | ファイル数 |
|---|---|
| globals.css | 1 |
| shelter/ | 4 (ShelterCard, ShelterDetailModal, ShelterDetailSections, SortToggle) |
| layout/ | 1 (DesktopSidebar) |
| filter/ | 1 (DisasterTypeFilter) |
| map/ | 5 (MapSearchBar, CurrentLocationButton, FilterButton, ShelterPopup, MapSkeleton) |
| chat/ | 5 (ChatFab, ChatModal, ChatMessage, ChatPanel, ChatInput) |
| pwa/ | 3 (InstallPrompt, UpdateNotification, OfflineIndicator) |
| error/ | 2 (NetworkError, ErrorBoundary) |
| legal/ | 1 (TermsModal) |
| App.tsx | 1 |

## 変更しなかった色

- 🔴 お気に入りハート (`fill-red-500`) — 赤=好きの意味
- 🔴 エラー状態 (`text-destructive`, `bg-red-100`)
- 🟢🟡🔵🟠 設備バッジ色 — 施設種別の意味
- 🟠🔴🌊 災害種別バッジ色 — 災害種別の意味
- 📍 避難所マーカー色 (`--color-shelter-*`)

## テスト計画

- [x] `pnpm lint` — エラー 0 件
- [x] `pnpm type-check` — 型エラー 0 件
- [x] `pnpm build` — ビルド成功
- [ ] デスクトップ表示: サイドバー、カード一覧、詳細モーダル、フィルタ
- [ ] モバイル表示: 地図、Drawer、フィルタドロワー、FAB
- [ ] カード選択/ホバー/お気に入りの状態遷移
- [ ] モーダル開閉
- [ ] チャットパネル (LLMステータスバナー含む)
- [ ] PWA プロンプト/通知/オフライン表示
- [ ] エラー画面表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)