### PR TITLE
feat(ui): ビジュアルポリッシュ (Phase 3)

### DIFF
--- a/src/components/chat/ChatFab.tsx
+++ b/src/components/chat/ChatFab.tsx
@@ -13,7 +13,7 @@ export function ChatFab({
     <button
       type="button"
       onClick={onClick}
-      className="flex h-12 w-12 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-lg transition-colors hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+      className="flex h-12 w-12 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-lg transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
       aria-label={ariaLabel}
     >
       <MessageCircleIcon className="h-6 w-6" aria-hidden="true" />

--- a/src/components/chat/ChatModal.tsx
+++ b/src/components/chat/ChatModal.tsx
@@ -44,7 +44,7 @@ export function ChatModal({
           <DialogClose asChild>
             <button
               type="button"
-              className="flex min-h-11 min-w-11 items-center justify-center rounded p-2 text-muted-foreground hover:bg-accent focus:outline-none focus:ring-2 focus:ring-ring"
+              className="flex min-h-11 min-w-11 items-center justify-center rounded p-2 text-muted-foreground hover:bg-accent focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
               aria-label="閉じる"
             >
               <XIcon className="h-5 w-5" aria-hidden="true" />

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -215,7 +215,7 @@ function LLMStatusBanner({
           <button
             type="button"
             onClick={onInit}
-            className="rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+            className="rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 transition-colors focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
           >
             AIモデルを有効にする
           </button>

--- a/src/components/error/ErrorBoundary.tsx
+++ b/src/components/error/ErrorBoundary.tsx
@@ -87,7 +87,7 @@ export class ErrorBoundary extends Component<
               <button
                 type="button"
                 onClick={this.reset}
-                className="w-full rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground shadow-sm hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 transition-colors"
+                className="w-full rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground shadow-sm hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 transition-colors"
               >
                 もう一度試す
               </button>
@@ -96,7 +96,7 @@ export class ErrorBoundary extends Component<
                 onClick={() => {
                   window.location.href = '/';
                 }}
-                className="w-full rounded-lg bg-secondary px-4 py-2 text-sm font-semibold text-secondary-foreground hover:bg-secondary/80 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 transition-colors"
+                className="w-full rounded-lg bg-secondary px-4 py-2 text-sm font-semibold text-secondary-foreground hover:bg-secondary/80 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 transition-colors"
               >
                 ホームに戻る
               </button>

--- a/src/components/legal/TermsModal.tsx
+++ b/src/components/legal/TermsModal.tsx
@@ -38,7 +38,7 @@ export function TermsModal({
           <DialogClose asChild>
             <button
               type="button"
-              className="flex min-h-11 min-w-11 items-center justify-center rounded-full p-2 transition-colors hover:bg-accent focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+              className="flex min-h-11 min-w-11 items-center justify-center rounded-full p-2 transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
               aria-label="閉じる"
             >
               <XIcon className="h-6 w-6" aria-hidden="true" />

--- a/src/components/map/CurrentLocationButton.tsx
+++ b/src/components/map/CurrentLocationButton.tsx
@@ -95,7 +95,7 @@ export const CurrentLocationButton: FC<CurrentLocationButtonProps> = ({
         // Googleマップ風: 円形、白背景、影
         'flex h-12 w-12 items-center justify-center rounded-full bg-card shadow-lg transition-all',
         'hover:shadow-xl active:shadow-md',
-        'focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+        'focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50',
         'disabled:cursor-not-allowed disabled:opacity-75',
         iconColor,
         className

--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -1,3 +1,4 @@
+import { InfoIcon, RefreshCwIcon } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import MapGL, {
   Marker,
@@ -202,30 +203,20 @@ export function ShelterMap({
               type="button"
               onClick={() => onRefresh()}
               disabled={isRefreshing}
-              className="flex h-10 w-10 items-center justify-center rounded-full border border-gray-200 bg-white shadow-lg transition-all hover:bg-gray-50 hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-60"
+              className="flex h-10 w-10 items-center justify-center rounded-full border border-border bg-card shadow-lg transition-all hover:bg-accent hover:shadow-xl focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:opacity-60"
               aria-label="避難所データを最新に更新"
               title="通信して最新の避難所データを取得します"
             >
               {isRefreshing ? (
                 <span
-                  className="h-4 w-4 animate-spin rounded-full border-2 border-gray-300 border-t-blue-600"
+                  className="h-4 w-4 animate-spin rounded-full border-2 border-primary/30 border-t-primary"
                   aria-hidden
                 />
               ) : (
-                <svg
-                  className="h-4 w-4 text-gray-600"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
+                <RefreshCwIcon
+                  className="h-4 w-4 text-muted-foreground"
                   aria-hidden
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
-                  />
-                </svg>
+                />
               )}
             </button>
           )}
@@ -233,24 +224,11 @@ export function ShelterMap({
             <button
               type="button"
               onClick={onShowTerms}
-              className="flex h-10 w-10 items-center justify-center rounded-full border border-gray-200 bg-white shadow-lg transition-all hover:bg-gray-50 hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+              className="flex h-10 w-10 items-center justify-center rounded-full border border-border bg-card shadow-lg transition-all hover:bg-accent hover:shadow-xl focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
               aria-label="利用規約を表示"
               title="利用規約"
             >
-              <svg
-                className="h-4 w-4 text-gray-600"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                />
-              </svg>
+              <InfoIcon className="h-4 w-4 text-muted-foreground" aria-hidden />
             </button>
           )}
         </div>
@@ -271,12 +249,12 @@ export function ShelterMap({
             >
               {/* 外側のパルスアニメーション */}
               <div
-                className="absolute h-6 w-6 animate-ping rounded-full bg-blue-400 opacity-75"
+                className="absolute h-6 w-6 animate-ping rounded-full bg-primary/60 opacity-75"
                 aria-hidden="true"
               />
               {/* 内側の固定円 */}
               <div
-                className="relative h-4 w-4 rounded-full border-2 border-white bg-blue-500 shadow-lg"
+                className="relative h-4 w-4 rounded-full border-2 border-background bg-primary shadow-lg"
                 aria-hidden="true"
               />
             </div>

--- a/src/components/map/ShelterPopup.tsx
+++ b/src/components/map/ShelterPopup.tsx
@@ -48,7 +48,7 @@ export function ShelterPopup({
           <button
             type="button"
             onClick={() => onShowDetail?.(shelter)}
-            className="w-full flex items-center justify-center gap-2 px-3 py-2 text-sm font-medium text-secondary-foreground bg-secondary hover:bg-secondary/80 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+            className="w-full flex items-center justify-center gap-2 px-3 py-2 text-sm font-medium text-secondary-foreground bg-secondary hover:bg-secondary/80 rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
             aria-label={`${name}の詳細を見る`}
           >
             <InfoIcon className="h-4 w-4" aria-hidden="true" />
@@ -64,7 +64,7 @@ export function ShelterPopup({
               );
               window.open(url, '_blank', 'noopener,noreferrer');
             }}
-            className="w-full flex items-center justify-center gap-2 px-3 py-2 text-sm font-medium text-primary-foreground bg-primary hover:bg-primary/90 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+            className="w-full flex items-center justify-center gap-2 px-3 py-2 text-sm font-medium text-primary-foreground bg-primary hover:bg-primary/90 rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
             aria-label={`${name}への経路案内`}
           >
             <MapIcon className="h-4 w-4" aria-hidden="true" />

--- a/src/components/pwa/InstallPrompt.tsx
+++ b/src/components/pwa/InstallPrompt.tsx
@@ -28,7 +28,7 @@ export function InstallPrompt(): ReactElement | null {
 
   return (
     <div
-      className="fixed bottom-4 left-4 right-4 z-50 rounded-lg bg-card p-4 shadow-xl ring-1 ring-border lg:left-auto lg:right-4 lg:w-96"
+      className="fixed bottom-[max(1rem,env(safe-area-inset-bottom))] left-4 right-4 z-50 rounded-lg bg-card p-4 shadow-xl ring-1 ring-border lg:left-auto lg:right-4 lg:w-96"
       role="alert"
     >
       <div className="flex items-start gap-3">

--- a/src/components/pwa/OfflineIndicator.tsx
+++ b/src/components/pwa/OfflineIndicator.tsx
@@ -14,7 +14,7 @@ export function OfflineIndicator(): ReactElement | null {
 
   return (
     <div
-      className="fixed bottom-4 left-1/2 z-50 -translate-x-1/2 rounded-lg bg-foreground px-4 py-2 text-sm text-background shadow-lg"
+      className="fixed bottom-[max(1rem,env(safe-area-inset-bottom))] left-1/2 z-50 -translate-x-1/2 rounded-lg bg-foreground px-4 py-2 text-sm text-background shadow-lg"
       role="alert"
       aria-live="polite"
     >

--- a/src/components/pwa/UpdateNotification.tsx
+++ b/src/components/pwa/UpdateNotification.tsx
@@ -32,7 +32,7 @@ export function UpdateNotification(): ReactElement | null {
 
   return (
     <div
-      className="fixed bottom-4 left-4 right-4 z-50 rounded-lg bg-card p-4 shadow-xl ring-1 ring-border lg:left-auto lg:right-4 lg:w-96"
+      className="fixed bottom-[max(1rem,env(safe-area-inset-bottom))] left-4 right-4 z-50 rounded-lg bg-card p-4 shadow-xl ring-1 ring-border lg:left-auto lg:right-4 lg:w-96"
       role="alert"
       aria-live="polite"
     >

--- a/src/components/shelter/ShelterCard.tsx
+++ b/src/components/shelter/ShelterCard.tsx
@@ -98,7 +98,7 @@ function ShelterCardComponent({
                 e.stopPropagation();
                 onToggleFavorite(id);
               }}
-              className="flex items-center justify-center rounded-full p-2.5 transition-colors hover:bg-accent focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+              className="flex items-center justify-center rounded-full p-2.5 transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
               aria-label={
                 isFavorite ? 'お気に入りから削除' : 'お気に入りに追加'
               }

--- a/src/components/shelter/ShelterDetailModal.tsx
+++ b/src/components/shelter/ShelterDetailModal.tsx
@@ -83,7 +83,7 @@ export function ShelterDetailModal({
               <button
                 type="button"
                 onClick={() => onToggleFavorite(id)}
-                className="flex min-h-11 min-w-11 items-center justify-center rounded-full p-2 transition-colors hover:bg-accent focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                className="flex min-h-11 min-w-11 items-center justify-center rounded-full p-2 transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
                 aria-label={
                   isFavorite ? 'お気に入りから削除' : 'お気に入りに追加'
                 }
@@ -121,7 +121,7 @@ export function ShelterDetailModal({
             <button
               type="button"
               onClick={() => copyAddress(address)}
-              className="group flex items-center gap-2 text-sm text-foreground/80 hover:text-primary transition-colors rounded focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+              className="group flex items-center gap-2 text-sm text-foreground/80 hover:text-primary transition-colors rounded focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
               aria-label={`住所をコピー: ${address}`}
             >
               <span>{address}</span>
@@ -199,7 +199,7 @@ export function ShelterDetailModal({
               </h3>
               <a
                 href={`tel:${contact}`}
-                className="text-sm text-primary hover:underline focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 rounded"
+                className="text-sm text-primary hover:underline focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 rounded"
               >
                 {contact}
               </a>

--- a/src/components/shelter/SortToggle.tsx
+++ b/src/components/shelter/SortToggle.tsx
@@ -32,7 +32,7 @@ export function SortToggle({
         value="distance"
         aria-label="距離順でソート"
         title={disabled ? '現在地を取得してください' : '距離順でソート'}
-        className="flex flex-1 items-center justify-center gap-1.5 rounded-lg px-3 py-2 data-[state=on]:bg-primary data-[state=on]:text-primary-foreground data-[state=on]:shadow-md"
+        className="flex flex-1 items-center justify-center gap-1.5 rounded-lg px-3 py-2 data-[state=on]:bg-primary data-[state=on]:text-primary-foreground data-[state=on]:shadow-sm"
       >
         <CrosshairIcon className="h-4 w-4" aria-hidden="true" />
         <span>距離順</span>
@@ -41,7 +41,7 @@ export function SortToggle({
       <ToggleGroupItem
         value="name"
         aria-label="名前順でソート"
-        className="flex flex-1 items-center justify-center gap-1.5 rounded-lg px-3 py-2 data-[state=on]:bg-primary data-[state=on]:text-primary-foreground data-[state=on]:shadow-md"
+        className="flex flex-1 items-center justify-center gap-1.5 rounded-lg px-3 py-2 data-[state=on]:bg-primary data-[state=on]:text-primary-foreground data-[state=on]:shadow-sm"
       >
         <ArrowDownAZIcon className="h-4 w-4" aria-hidden="true" />
         <span>名前順</span>


### PR DESCRIPTION
## 概要

UIブラッシュアップ Phase 3: ビジュアルポリッシュ + 災害種別アイコンリデザイン。15ファイル, -137行/+47行。

## 変更内容

### 3A: Map.tsx 残修正
- ハードコード色 (`border-gray-200`, `bg-white`, `ring-blue-500`, `text-gray-600`) をセマンティックトークンに置換
- インラインSVG (更新アイコン, 利用規約アイコン) → `RefreshCwIcon` / `InfoIcon` に置換
- 現在地マーカー: `bg-blue-400/500` → `bg-primary/60`, `bg-primary`

### 3B: フォーカスリング統一
- `focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2` → `focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50` (shadcn パターン)
- 対象: 13箇所 (ErrorBoundary, ShelterPopup, TermsModal, CurrentLocationButton, ShelterCard, ShelterDetailModal, ChatModal, ChatPanel, ChatFab)

### 3C: スピナー統一
- Phase 1 で全て `border-primary/30 border-t-primary` に統一済み (追加変更なし)

### 3D: モバイルセーフエリア
- `InstallPrompt`, `UpdateNotification`, `OfflineIndicator`: `bottom-4` → `bottom-[max(1rem,env(safe-area-inset-bottom))]`
- iPhoneのホームバー領域と重ならないように

### 3E: SortToggle 微調整
- アクティブ状態: `shadow-md` → `shadow-sm` (視覚的に軽く)

### 3F: 災害種別アイコンリデザイン
自作SVG 5個 → lucide 3個 + カスタム 2個に整理 (-87行/+19行)

| 災害種別 | Before | After |
|---|---|---|
| 洪水 | 自作2本波線 | lucide `Waves` (3本の波線) |
| 津波 | 単純なS字カーブ | カスタム (立ち上がる大波 + 地面線) |
| 土砂災害 | 三角 + 粗い丸3つ | カスタム (山 + ジグザグ亀裂線) |
| 地震 | ViewBox半分のジグザグ | lucide `Activity` (全幅の地震計波形) |
| 火災 | 薄い炎の輪郭線 | lucide `Flame` (塗りのある炎) |

## テスト計画

- [x] `pnpm lint` エラー 0 件
- [x] `pnpm type-check` 型エラー 0 件
- [x] `pnpm build` ビルド成功
- [x] デスクトップ: 災害種別フィルタのアイコン表示・選択状態確認
- [x] モバイル: フィルタドロワーのアイコン表示確認
- [ ] Tab キーでフォーカス移動してリングの表示を確認
- [ ] PWA通知のセーフエリア確認 (iPhone実機)

🤖 Generated with [Claude Code](https://claude.com/claude-code)