### PR TITLE
feat(ui): add designer credit to top page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -123,6 +123,9 @@ function HomePageContent({ mainContentId }: { mainContentId: string }) {
         <div className="absolute bottom-[calc(8.5rem+env(safe-area-inset-bottom))] right-4 z-10">
           <ChatFab onClick={() => setChatModalOpen(true)} />
         </div>
+        <p className="absolute bottom-[max(0.5rem,env(safe-area-inset-bottom))] left-2 z-10 text-[10px] text-muted-foreground/70">
+          Designed by Yusaku Matsukawa
+        </p>
       </div>
 
       {/* デスクトップレイアウト */}

--- a/src/components/layout/DesktopSidebar.tsx
+++ b/src/components/layout/DesktopSidebar.tsx
@@ -198,6 +198,12 @@ export function DesktopSidebar({
           />
         )}
       </nav>
+
+      <footer className="border-t px-4 py-2">
+        <p className="text-xs text-muted-foreground">
+          Designed by Yusaku Matsukawa
+        </p>
+      </footer>
     </aside>
   );
 }


### PR DESCRIPTION
## Summary
- デスクトップ: サイドバー最下部にフッターとして `Designed by Yusaku Matsukawa` を常時表示
- モバイル: 地図の左下に控えめなオーバーレイとしてクレジットを常時表示

Closes #334

## Test plan
- [ ] デスクトップ (>=1024px): サイドバー最下部にクレジットが表示される
- [ ] モバイル (<1024px): 地図左下にクレジットが表示される
- [ ] MapLibre アトリビューションと重ならない
- [ ] 操作を妨げない

🤖 Generated with [Claude Code](https://claude.com/claude-code)