### PR TITLE
chore(deps): Biome スキーマを 2.4.8 に同期

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.14/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.8/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",


### PR DESCRIPTION
## Summary
- `biome.json` の `$schema` を `2.3.14` → `2.4.8` に更新（`biome migrate` で適用）
- CI で毎回出ていたスキーマバージョン不一致の警告を解消

## Test plan
- [x] `pnpm lint` エラー 0 件
- [ ] CI の Quality Check が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)