### PR TITLE
chore(biome): migrate config schema

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.9/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/scripts/generate-map-tiles.ts
+++ b/scripts/generate-map-tiles.ts
@@ -59,7 +59,7 @@ function computeBbox(): string {
 
 /** pmtiles CLI のパスを解決する（PATH → キャッシュ → 自動ダウンロード） */
 async function resolvePmtilesCli(): Promise<string> {
-  const fromEnv = process.env['PMTILES_BIN'];
+  const fromEnv = process.env.PMTILES_BIN;
   if (fromEnv) {
     return fromEnv;
   }
@@ -140,7 +140,7 @@ async function fetchLatestBuildKey(): Promise<string> {
 }
 
 async function main(): Promise<void> {
-  const maxzoom = process.env['TILES_MAXZOOM'] ?? '15';
+  const maxzoom = process.env.TILES_MAXZOOM ?? '15';
   const bbox = computeBbox();
   console.log(`🗺️  対象範囲 bbox: ${bbox} / maxzoom: ${maxzoom}`);
 


### PR DESCRIPTION
## Summary
- Migrate Biome config schema from 2.4.9 to 2.4.16
- Replace computed env var access with literal property access to remove Biome info messages

## Test Plan
- [x] pnpm lint
- [x] pnpm format:check
- [x] pnpm type-check
- [x] pnpm build

Closes #424