### PR TITLE
fix(map): 初期ロードの負荷を軽減

### DIFF
--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -1,21 +1,21 @@
 import { expect, test } from '@playwright/test';
 
 test.describe('地図ページの基本表示', () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto('/');
-  });
-
   test('ページが正常に読み込まれる', async ({ page }) => {
+    await page.goto('/');
     // map-container が存在すること
-    const mapContainer = page.locator('.map-container').first();
+    const mapContainer = page.locator('.map-container');
     await expect(mapContainer).toBeAttached({ timeout: 10_000 });
+    await expect(mapContainer).toHaveCount(1);
   });
 
   test('タイトルが正しい', async ({ page }) => {
+    await page.goto('/');
     await expect(page).toHaveTitle(/鳴門/);
   });
 
   test('スクリーンリーダー用のステータスが存在する', async ({ page }) => {
+    await page.goto('/');
     const status = page.locator('[role="status"]');
     await expect(status.first()).toBeAttached();
   });
@@ -43,13 +43,18 @@ test.describe('オフライン対応', () => {
   test('Service Worker が登録される', async ({ page }) => {
     await page.goto('/');
 
-    const swRegistered = await page.evaluate(async () => {
-      if (!('serviceWorker' in navigator)) return false;
-      const registration = await navigator.serviceWorker.getRegistration('/');
-      return registration !== undefined;
-    });
-
-    expect(swRegistered).toBe(true);
+    await expect
+      .poll(
+        () =>
+          page.evaluate(async () => {
+            if (!('serviceWorker' in navigator)) return false;
+            const registration =
+              await navigator.serviceWorker.getRegistration('/');
+            return registration !== undefined;
+          }),
+        { timeout: 15_000 }
+      )
+      .toBe(true);
   });
 
   test('manifest.json が取得できる', async ({ page }) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useEffect, useId } from 'react';
+import { lazy, Suspense, useCallback, useEffect, useId, useState } from 'react';
 import { toast } from 'sonner';
 import { Router } from 'wouter';
 import { SkipLink } from '@/components/a11y/SkipLink';
@@ -15,6 +15,7 @@ import { ShelterDetailModal } from '@/components/shelter/ShelterDetailModal';
 import { Toaster } from '@/components/ui/sonner';
 import { FilterProvider } from '@/contexts/FilterContext';
 import { useHomePageState } from '@/hooks/useHomePageState';
+import { useIsDesktop } from '@/hooks/useIsDesktop';
 import { calculateDistance, toCoordinates } from '@/lib/geo';
 
 const ShelterMap = lazy(() =>
@@ -32,7 +33,13 @@ const MAP_LOADING_FALLBACK = (
   </div>
 );
 
-function HomePageContent({ mainContentId }: { mainContentId: string }) {
+interface HomePageContentProps {
+  mainContentId: string;
+  onMapReady: () => void;
+}
+
+function HomePageContent({ mainContentId, onMapReady }: HomePageContentProps) {
+  const isDesktop = useIsDesktop();
   const {
     filteredShelters,
     allSheltersCount,
@@ -87,22 +94,33 @@ function HomePageContent({ mainContentId }: { mainContentId: string }) {
     );
   }
 
-  if (isLoading) {
-    return (
-      <div className="flex min-h-screen items-center justify-center">
-        <div className="text-center">
-          <div className="mx-auto h-12 w-12 animate-spin rounded-full border-4 border-primary/30 border-t-primary" />
-          <p className="mt-4 text-sm text-muted-foreground">読み込み中...</p>
-        </div>
-      </div>
-    );
-  }
-
   return (
     <>
-      {/* モバイルレイアウト */}
-      <div className="relative flex h-screen flex-col lg:hidden">
-        <main id={mainContentId} className="relative min-h-0 flex-1">
+      <div className="relative flex h-screen flex-col lg:flex-row lg:overflow-hidden">
+        {isDesktop && (
+          <div className="h-full">
+            <DesktopSidebar
+              mainContentId={mainContentId}
+              filteredShelters={filteredShelters}
+              allSheltersCount={allSheltersCount}
+              listShelters={listShelters}
+              selectedShelterId={selectedShelterId}
+              onShelterSelect={setSelectedShelterId}
+              onShowDetail={openDetail}
+              onShowTerms={openTerms}
+              onRefresh={refresh}
+              isRefreshing={isRefreshing}
+              position={position ?? null}
+              favorites={favorites}
+              onToggleFavorite={toggleFavorite}
+              sortMode={sortMode}
+              onSortModeChange={setSortMode}
+              listFilter={listFilter}
+              onListFilterChange={setListFilter}
+            />
+          </div>
+        )}
+        <main id={mainContentId} className="relative h-full flex-1">
           <Suspense fallback={MAP_LOADING_FALLBACK}>
             <ShelterMap
               shelters={filteredShelters}
@@ -117,50 +135,22 @@ function HomePageContent({ mainContentId }: { mainContentId: string }) {
               isRefreshing={isRefreshing}
               onShowTerms={openTerms}
               onOpenChat={() => setChatModalOpen(true)}
+              onMapReady={onMapReady}
             />
           </Suspense>
+          {isLoading && (
+            <div
+              className="absolute left-1/2 top-4 z-20 -translate-x-1/2 rounded-full border border-border bg-card/95 px-4 py-2 text-sm text-muted-foreground shadow-lg"
+              role="status"
+              aria-live="polite"
+            >
+              避難所データを読み込んでいます...
+            </div>
+          )}
         </main>
-        <p className="absolute bottom-[max(1rem,env(safe-area-inset-bottom))] left-2 z-10 text-[10px] text-muted-foreground/70">
+        <p className="absolute bottom-[max(1rem,env(safe-area-inset-bottom))] left-2 z-10 text-[10px] text-muted-foreground/70 lg:hidden">
           Designed by Yusaku Matsukawa
         </p>
-      </div>
-
-      {/* デスクトップレイアウト */}
-      <div className="hidden lg:flex lg:h-screen lg:flex-row lg:overflow-hidden">
-        <DesktopSidebar
-          mainContentId={mainContentId}
-          filteredShelters={filteredShelters}
-          allSheltersCount={allSheltersCount}
-          listShelters={listShelters}
-          selectedShelterId={selectedShelterId}
-          onShelterSelect={setSelectedShelterId}
-          onShowDetail={openDetail}
-          onShowTerms={openTerms}
-          onRefresh={refresh}
-          isRefreshing={isRefreshing}
-          position={position ?? null}
-          favorites={favorites}
-          onToggleFavorite={toggleFavorite}
-          sortMode={sortMode}
-          onSortModeChange={setSortMode}
-          listFilter={listFilter}
-          onListFilterChange={setListFilter}
-        />
-
-        <main id={mainContentId} className="relative h-full flex-1">
-          <Suspense fallback={MAP_LOADING_FALLBACK}>
-            <ShelterMap
-              shelters={filteredShelters}
-              selectedShelterId={selectedShelterId}
-              onShelterSelect={setSelectedShelterId}
-              onShowDetail={openDetail}
-              position={position}
-              geolocationState={geolocationState}
-              geolocationError={geolocationError}
-              onGetCurrentPosition={getCurrentPosition}
-            />
-          </Suspense>
-        </main>
       </div>
 
       {detailModalShelter && (
@@ -196,14 +186,27 @@ function HomePageContent({ mainContentId }: { mainContentId: string }) {
 
 function App() {
   const mainContentId = useId();
+  const [mapReady, setMapReady] = useState(false);
+  const handleMapReady = useCallback(() => setMapReady(true), []);
+
+  // 地図読み込みに失敗しても、次回のオフライン利用に備えて登録は継続する
+  useEffect(() => {
+    if (mapReady) return;
+    const timeoutId = window.setTimeout(() => setMapReady(true), 10_000);
+    return () => window.clearTimeout(timeoutId);
+  }, [mapReady]);
+
   return (
     <div className="font-sans antialiased">
       <SkipLink targetId={mainContentId} />
-      <ServiceWorkerRegistration />
+      <ServiceWorkerRegistration enabled={mapReady} />
       <ErrorBoundary>
         <FilterProvider>
           <Router>
-            <HomePageContent mainContentId={mainContentId} />
+            <HomePageContent
+              mainContentId={mainContentId}
+              onMapReady={handleMapReady}
+            />
           </Router>
         </FilterProvider>
       </ErrorBoundary>

--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -39,6 +39,8 @@ interface MapProps {
   onShowTerms?: () => void;
   /** モバイル用: チャットモーダルを開く */
   onOpenChat?: () => void;
+  /** 初期地図の表示が完了したときに呼ぶ */
+  onMapReady?: () => void;
 }
 
 export function ShelterMap({
@@ -54,6 +56,7 @@ export function ShelterMap({
   isRefreshing = false,
   onShowTerms,
   onOpenChat,
+  onMapReady,
 }: MapProps) {
   const [selectedShelter, setSelectedShelter] = useState<ShelterFeature | null>(
     null
@@ -146,6 +149,7 @@ export function ShelterMap({
         style={{ width: '100%', height: '100%' }}
         mapStyle={mapStyle}
         onMove={handleMove}
+        {...(onMapReady ? { onLoad: onMapReady } : {})}
       >
         <MapController
           selectedShelterId={selectedShelterId}

--- a/src/components/pwa/ServiceWorkerRegistration.tsx
+++ b/src/components/pwa/ServiceWorkerRegistration.tsx
@@ -2,10 +2,19 @@ import { useEffect } from 'react';
 
 /**
  * Service Worker登録コンポーネント
- * 本番ビルドで vite-plugin-pwa が生成した sw.js を登録する
+ * 本番ビルドで vite-plugin-pwa が生成した sw.js を登録する。
+ * 初回の大量precacheが地図表示と競合しないよう、地図の準備完了後に登録する。
  */
-export function ServiceWorkerRegistration(): null {
+export function ServiceWorkerRegistration({
+  enabled,
+}: {
+  enabled: boolean;
+}): null {
   useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
     if (typeof window === 'undefined') {
       return;
     }
@@ -56,7 +65,7 @@ export function ServiceWorkerRegistration(): null {
       }
     };
 
-    // ページ読み込み完了後に登録
+    // 地図準備完了後、かつページ読み込み完了後に登録
     if (document.readyState === 'complete') {
       registerServiceWorker();
     } else {
@@ -67,7 +76,7 @@ export function ServiceWorkerRegistration(): null {
     return () => {
       window.removeEventListener('load', registerServiceWorker);
     };
-  }, []);
+  }, [enabled]);
 
   // このコンポーネントは何もレンダリングしない
   return null;

--- a/src/hooks/useIsDesktop.ts
+++ b/src/hooks/useIsDesktop.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+
+const DESKTOP_MEDIA_QUERY = '(min-width: 1024px)';
+
+function getIsDesktop(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia(DESKTOP_MEDIA_QUERY).matches
+  );
+}
+
+/** Tailwind の lg ブレークポイントと同期したデスクトップ表示判定 */
+export function useIsDesktop(): boolean {
+  const [isDesktop, setIsDesktop] = useState(getIsDesktop);
+
+  useEffect(() => {
+    if (typeof window.matchMedia !== 'function') return;
+    const mediaQuery = window.matchMedia(DESKTOP_MEDIA_QUERY);
+    const handleChange = (event: MediaQueryListEvent): void => {
+      setIsDesktop(event.matches);
+    };
+
+    setIsDesktop(mediaQuery.matches);
+    mediaQuery.addEventListener('change', handleChange);
+    return () => mediaQuery.removeEventListener('change', handleChange);
+  }, []);
+
+  return isDesktop;
+}


### PR DESCRIPTION
## 概要

- モバイル用・デスクトップ用の地図を同時にマウントせず、レスポンシブなMapLibreインスタンス1つに統合
- 避難所GeoJSONの取得完了を待たずに地図の読み込みを開始し、データ取得中は非ブロッキングの表示を追加
- デスクトップ用サイドバーをデスクトップ幅のときだけマウント
- 初回の約23MBのService Worker precacheを地図表示完了後へ延期し、10秒後のフォールバックを追加
- 地図インスタンスが1つであることと、遅延したService Worker登録をE2Eテストで検証

## 原因

モバイル用とデスクトップ用の地図レイアウトが両方ともマウントされ、片方をCSSで非表示にしていました。そのため、MapLibreのcanvasが2枚生成され、382件の避難所マーカーも二重に描画されていました。

また、初回のService Worker登録時に約23MBのオフライン資産のprecacheが地図の初期表示と同時に始まり、通信帯域とI/Oが競合していました。

## 利用者への影響

初期表示時の地図描画とマーカー生成の処理量を削減し、初回precacheとの競合を回避します。インストール完了後の完全オフライン動作は引き続き利用できます。

## 検証

- `pnpm lint`
- `pnpm type-check`
- `pnpm test:run` — 158件成功
- `pnpm build`
- `pnpm test:e2e` — 完全オフライン地図を含む8件成功
